### PR TITLE
Develop retinafix

### DIFF
--- a/MapView/Map/RMMapTiledLayerView.m
+++ b/MapView/Map/RMMapTiledLayerView.m
@@ -45,7 +45,7 @@
     self.useSnapshotRenderer = NO;
 
     CATiledLayer *tiledLayer = [self tiledLayer];
-    size_t levelsOf2xMagnification = _mapView.tileSourcesContainer.maxZoom;
+    size_t levelsOf2xMagnification = _mapView.tileSourcesContainer.maxZoom + 1;
     if (_mapView.adjustTilesForRetinaDisplay) levelsOf2xMagnification += 1;
     tiledLayer.levelsOfDetail = levelsOf2xMagnification;
     tiledLayer.levelsOfDetailBias = levelsOf2xMagnification;

--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -3067,7 +3067,7 @@
 
 - (void)locationManager:(CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status
 {
-    if (status != kCLAuthorizationStatusAuthorized)
+    if (status == kCLAuthorizationStatusDenied || status == kCLAuthorizationStatusRestricted)
     {
         self.userTrackingMode  = RMUserTrackingModeNone;
         self.showsUserLocation = NO;

--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -1100,6 +1100,9 @@
     int tileSideLength = [_tileSourcesContainer tileSideLength];
     CGSize contentSize = CGSizeMake(tileSideLength, tileSideLength); // zoom level 1
 
+    float retinaCorrectedMaxZoom = _adjustTilesForRetinaDisplay ? [self maxZoom] + 1 : [self maxZoom];
+    float retinaCorrectedMinZoom = _adjustTilesForRetinaDisplay ? [self minZoom] + 1 : [self minZoom];
+    
     _mapScrollView = [[RMMapScrollView alloc] initWithFrame:[self bounds]];
     _mapScrollView.delegate = self;
     _mapScrollView.opaque = NO;
@@ -1111,8 +1114,8 @@
     _mapScrollView.bounces = _enableBouncing;
     _mapScrollView.bouncesZoom = _enableBouncing;
     _mapScrollView.contentSize = contentSize;
-    _mapScrollView.minimumZoomScale = exp2f([self minZoom]);
-    _mapScrollView.maximumZoomScale = exp2f([self maxZoom]);
+    _mapScrollView.minimumZoomScale = exp2f(retinaCorrectedMinZoom);
+    _mapScrollView.maximumZoomScale = exp2f(retinaCorrectedMaxZoom);
     _mapScrollView.contentOffset = CGPointMake(0.0, 0.0);
     _mapScrollView.clipsToBounds = NO;
 

--- a/MapView/MapView.xcodeproj/project.pbxproj
+++ b/MapView/MapView.xcodeproj/project.pbxproj
@@ -101,10 +101,9 @@
 		DD3BEF7A15913C55007892D8 /* RMAttributionViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = DD3BEF7815913C55007892D8 /* RMAttributionViewController.m */; };
 		DD5A200915CAD03700FE4157 /* libGRMustache4-iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DD5A200815CAD03700FE4157 /* libGRMustache4-iOS.a */; };
 		DD5A200B15CAD09400FE4157 /* GRMustache.h in Headers */ = {isa = PBXBuildFile; fileRef = DD5A200A15CAD09400FE4157 /* GRMustache.h */; };
-		DD6380DD152E72880074E66E /* RMMapBoxSource.h in Headers */ = {isa = PBXBuildFile; fileRef = DD6380DB152E72880074E66E /* RMMapBoxSource.h */; };
-		DD6380DE152E72880074E66E /* RMMapBoxSource.m in Sources */ = {isa = PBXBuildFile; fileRef = DD6380DC152E72880074E66E /* RMMapBoxSource.m */; };
 		DD5FA1EB15E2B020004EB6C5 /* RMLoadingTileView.h in Headers */ = {isa = PBXBuildFile; fileRef = DD5FA1E915E2B020004EB6C5 /* RMLoadingTileView.h */; };
 		DD5FA1EC15E2B020004EB6C5 /* RMLoadingTileView.m in Sources */ = {isa = PBXBuildFile; fileRef = DD5FA1EA15E2B020004EB6C5 /* RMLoadingTileView.m */; };
+		DD6380DD152E72880074E66E /* (null) in Headers */ = {isa = PBXBuildFile; };
 		DD8CDB4A14E0507100B73EB9 /* RMMapQuestOSMSource.h in Headers */ = {isa = PBXBuildFile; fileRef = DD8CDB4814E0507100B73EB9 /* RMMapQuestOSMSource.h */; };
 		DD8CDB4B14E0507100B73EB9 /* RMMapQuestOSMSource.m in Sources */ = {isa = PBXBuildFile; fileRef = DD8CDB4914E0507100B73EB9 /* RMMapQuestOSMSource.m */; };
 		DD8FD7541559E4A40044D96F /* RMUserLocation.h in Headers */ = {isa = PBXBuildFile; fileRef = DD8FD7521559E4A40044D96F /* RMUserLocation.h */; };
@@ -600,7 +599,7 @@
 				1607499514E120A100D535F5 /* RMGenericMapSource.h in Headers */,
 				16FFF2CB14E3DBF700A170EC /* RMMapQuestOpenAerialSource.h in Headers */,
 				DDC4BED5152E3BD700089409 /* RMInteractiveSource.h in Headers */,
-				DD6380DD152E72880074E66E /* RMMapBoxSource.h in Headers */,
+				DD6380DD152E72880074E66E /* (null) in Headers */,
 				DD3BEF7915913C55007892D8 /* RMAttributionViewController.h in Headers */,
 				DD8FD7541559E4A40044D96F /* RMUserLocation.h in Headers */,
 				DDA6B8BD155CAB67003DB5D8 /* RMUserTrackingBarButtonItem.h in Headers */,


### PR DESCRIPTION
Max zoom level is never used on retina devices when adjustTilesForRetinaDisplay flag turned to YES.
The issue #42 seems to be reappeared. Maybe something was changed in the render pipeline in August?
This commit patches this out, but rendering on retina display should be addressed with a stronger approach. 
