### PR TITLE
RMMBTilesSource bug fix: added memory tile cache related code

### DIFF
--- a/MapView/Map/RMMBTilesSource.m
+++ b/MapView/Map/RMMBTilesSource.m
@@ -100,6 +100,8 @@
     
     __block UIImage *image;
 
+    [tileCache retain];
+
     [queue inDatabase:^(FMDatabase *db)
     {
         FMResultSet *results = [db executeQuery:@"select tile_data from tiles where zoom_level = ? and tile_column = ? and tile_row = ?", 
@@ -122,6 +124,11 @@
         [results close];
     }];
 
+    if (image)
+        [tileCache addImage:image forTile:tile withCacheKey:[self uniqueTilecacheKey]];
+
+    [tileCache release];
+    
     dispatch_async(dispatch_get_main_queue(), ^(void)
     {
         [[NSNotificationCenter defaultCenter] postNotificationName:RMTileRetrieved object:[NSNumber numberWithUnsignedLongLong:RMTileKey(tile)]];

--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -1100,6 +1100,9 @@
     int tileSideLength = [_tileSourcesContainer tileSideLength];
     CGSize contentSize = CGSizeMake(tileSideLength, tileSideLength); // zoom level 1
 
+    float retinaCorrectedMaxZoom = _adjustTilesForRetinaDisplay ? [self maxZoom] : [self maxZoom] + 0.99;
+    float retinaCorrectedMinZoom = _adjustTilesForRetinaDisplay ? [self minZoom] -0.99 : [self minZoom];
+    
     _mapScrollView = [[RMMapScrollView alloc] initWithFrame:[self bounds]];
     _mapScrollView.delegate = self;
     _mapScrollView.opaque = NO;
@@ -1111,8 +1114,8 @@
     _mapScrollView.bounces = _enableBouncing;
     _mapScrollView.bouncesZoom = _enableBouncing;
     _mapScrollView.contentSize = contentSize;
-    _mapScrollView.minimumZoomScale = exp2f([self minZoom]);
-    _mapScrollView.maximumZoomScale = exp2f([self maxZoom]);
+    _mapScrollView.minimumZoomScale = exp2f(retinaCorrectedMinZoom);
+    _mapScrollView.maximumZoomScale = exp2f(retinaCorrectedMaxZoom);
     _mapScrollView.contentOffset = CGPointMake(0.0, 0.0);
     _mapScrollView.clipsToBounds = NO;
 


### PR DESCRIPTION
Hi,
as it seems (I hope not to have misunderstood your caching flow) RMMBTilesSource class missed the caching-related code, never adding the new fetched tiles in the cache. As a consequence, the renderer was falling in an infinite loop, the device was overheating etc.
This was related with issue #104 too: since the renderer did never find the tile at the requested zoom level in the cache, it was always fetching the tile at the previous zoom level, resulting in low quality rendering and missing the maximum zoom level present in file.
