### PR TITLE
Allows for drawing of bezier curves in RMShape

### DIFF
--- a/MapView/Map/RMShape.h
+++ b/MapView/Map/RMShape.h
@@ -107,6 +107,34 @@
 *   @param coordinate The coordinate to draw to. */
 - (void)addLineToCoordinate:(CLLocationCoordinate2D)coordinate;
 
+/** Draw a curve from the current pen location to a coordinate.
+ *  @param coordinate The coordinate to draw to.
+ *  @param controlCoordinate1 The first control coordinate.
+ *  @param controlCoordinate2 The second control coordinate. */
+- (void)addCurveToCoordinate:(CLLocationCoordinate2D)coordinate
+          controlCoordinate1:(CLLocationCoordinate2D)controlCoordinate1
+          controlCoordinate2:(CLLocationCoordinate2D)controlCoordinate2;
+
+/** Draw a quad curve from the current pen location to a coordinate.
+ *  @param coordinate The coordinate to draw to.
+ *  @param controlCoordinate The control coordinate. */
+- (void)addQuadCurveToCoordinate:(CLLocationCoordinate2D)coordinate
+               controlCoordinate:(CLLocationCoordinate2D)controlCoordinate;
+
+/** Draw a curve from the current pen location to a projected point.
+ *  @param projectedPoint The projected point to draw to.
+ *  @param controlProjectedPoint1 The first control projected point.
+ *  @param controlProjectedPoint2 The second control projected point. */
+- (void)addCurveToProjectedPoint:(RMProjectedPoint)projectedPoint
+          controlProjectedPoint1:(RMProjectedPoint)controlProjectedPoint1
+          controlProjectedPoint2:(RMProjectedPoint)controlProjectedPoint2;
+
+/** Draw a quad curve from the current pen location to a projected point.
+ *  @param projectedPoint The projected point to draw to.
+ *  @param controlProjectedPoint The control projected point. */
+- (void)addQuadCurveToProjectedPoint:(RMProjectedPoint)projectedPoint
+               controlProjectedPoint:(RMProjectedPoint)controlProjectedPoint;
+
 /** Alter the path without rerecalculating the geometry. Recommended for many operations in order to increase performance. 
 *   @param block A block containing the operations to perform. */
 - (void)performBatchOperations:(void (^)(RMShape *aShape))block;

--- a/MapView/Map/RMShape.m
+++ b/MapView/Map/RMShape.m
@@ -288,7 +288,11 @@
 
 #pragma mark -
 
-- (void)addPointToProjectedPoint:(RMProjectedPoint)point withDrawing:(BOOL)isDrawing
+
+- (void)addCurveToProjectedPoint:(RMProjectedPoint)point
+                   controlPoint1:(RMProjectedPoint)controlPoint1
+                   controlPoint2:(RMProjectedPoint)controlPoint2
+                     withDrawing:(BOOL)isDrawing
 {
     [points addObject:[[[CLLocation alloc] initWithLatitude:[mapView projectedPointToCoordinate:point].latitude longitude:[mapView projectedPointToCoordinate:point].longitude] autorelease]];
 
@@ -306,10 +310,29 @@
         point.x = point.x - projectedLocation.x;
         point.y = point.y - projectedLocation.y;
 
-        if (isDrawing)
-            [bezierPath addLineToPoint:CGPointMake(point.x, -point.y)];
-        else
+        if (isDrawing) {
+            if (isnan(controlPoint1.x) && isnan(controlPoint2.x)) {
+                [bezierPath addLineToPoint:CGPointMake(point.x, -point.y)];
+                
+            } else if (isnan(controlPoint2.x)) {
+                controlPoint1.x = controlPoint1.x - projectedLocation.x;
+                controlPoint1.y = controlPoint1.y - projectedLocation.y;
+                
+                [bezierPath addQuadCurveToPoint:CGPointMake(point.x, -point.y)
+                                   controlPoint:CGPointMake(controlPoint1.x, -controlPoint1.y)];
+            } else {
+                controlPoint1.x = controlPoint1.x - projectedLocation.x;
+                controlPoint1.y = controlPoint1.y - projectedLocation.y;
+                controlPoint2.x = controlPoint2.x - projectedLocation.x;
+                controlPoint2.y = controlPoint2.y - projectedLocation.y;
+                
+                [bezierPath addCurveToPoint:CGPointMake(point.x, -point.y)
+                              controlPoint1:CGPointMake(controlPoint1.x, -controlPoint1.y)
+                              controlPoint2:CGPointMake(controlPoint2.x, -controlPoint2.y)];
+            }
+        } else {
             [bezierPath moveToPoint:CGPointMake(point.x, -point.y)];
+        }
 
         lastScale = 0.0;
         [self recalculateGeometryAnimated:NO];
@@ -320,7 +343,10 @@
 
 - (void)moveToProjectedPoint:(RMProjectedPoint)projectedPoint
 {
-    [self addPointToProjectedPoint:projectedPoint withDrawing:NO];
+    [self addCurveToProjectedPoint:projectedPoint
+                     controlPoint1:RMProjectedPointMake((double)NAN, (double)NAN)
+                     controlPoint2:RMProjectedPointMake((double)NAN, (double)NAN)
+                       withDrawing:NO];
 }
 
 - (void)moveToScreenPoint:(CGPoint)point
@@ -337,7 +363,10 @@
 
 - (void)addLineToProjectedPoint:(RMProjectedPoint)projectedPoint
 {
-    [self addPointToProjectedPoint:projectedPoint withDrawing:YES];
+    [self addCurveToProjectedPoint:projectedPoint
+                     controlPoint1:RMProjectedPointMake((double)NAN, (double)NAN)
+                     controlPoint2:RMProjectedPointMake((double)NAN, (double)NAN)
+                       withDrawing:YES];
 }
 
 - (void)addLineToScreenPoint:(CGPoint)point
@@ -350,6 +379,52 @@
 {
     RMProjectedPoint mercator = [[mapView projection] coordinateToProjectedPoint:coordinate];
     [self addLineToProjectedPoint:mercator];
+}
+
+- (void)addCurveToCoordinate:(CLLocationCoordinate2D)coordinate
+          controlCoordinate1:(CLLocationCoordinate2D)controlCoordinate1
+          controlCoordinate2:(CLLocationCoordinate2D)controlCoordinate2
+{
+    RMProjectedPoint projectedPoint = [[mapView projection]
+                                       coordinateToProjectedPoint:coordinate];
+    RMProjectedPoint controlProjectedPoint1 = [[mapView projection]
+                                               coordinateToProjectedPoint:controlCoordinate1];
+    RMProjectedPoint controlProjectedPoint2 = [[mapView projection]
+                                               coordinateToProjectedPoint:controlCoordinate2];
+    [self addCurveToProjectedPoint:projectedPoint
+            controlProjectedPoint1:controlProjectedPoint1
+            controlProjectedPoint2:controlProjectedPoint2];
+}
+
+- (void)addQuadCurveToCoordinate:(CLLocationCoordinate2D)coordinate
+               controlCoordinate:(CLLocationCoordinate2D)controlCoordinate
+{
+    RMProjectedPoint projectedPoint = [[mapView projection]
+                                       coordinateToProjectedPoint:coordinate];
+    RMProjectedPoint controlProjectedPoint = [[mapView projection]
+                                              coordinateToProjectedPoint:controlCoordinate];
+    [self addQuadCurveToProjectedPoint:projectedPoint
+                 controlProjectedPoint:controlProjectedPoint];
+    
+}
+
+- (void)addCurveToProjectedPoint:(RMProjectedPoint)projectedPoint
+          controlProjectedPoint1:(RMProjectedPoint)controlProjectedPoint1
+          controlProjectedPoint2:(RMProjectedPoint)controlProjectedPoint2
+{
+    [self addCurveToProjectedPoint:projectedPoint
+                     controlPoint1:controlProjectedPoint1
+                     controlPoint2:controlProjectedPoint2
+                       withDrawing:YES];
+}
+
+- (void)addQuadCurveToProjectedPoint:(RMProjectedPoint)projectedPoint
+               controlProjectedPoint:(RMProjectedPoint)controlProjectedPoint
+{
+    [self addCurveToProjectedPoint:projectedPoint
+                     controlPoint1:controlProjectedPoint
+                     controlPoint2:RMProjectedPointMake((double)NAN, (double)NAN)
+                       withDrawing:YES];
 }
 
 - (void)performBatchOperations:(void (^)(RMShape *aShape))block


### PR DESCRIPTION
Adds the following methods to RMShape:

```
- (void)addCurveToCoordinate:(CLLocationCoordinate2D)coordinate
          controlCoordinate1:(CLLocationCoordinate2D)controlCoordinate1
          controlCoordinate2:(CLLocationCoordinate2D)controlCoordinate2;

- (void)addQuadCurveToCoordinate:(CLLocationCoordinate2D)coordinate
               controlCoordinate:(CLLocationCoordinate2D)controlCoordinate;

- (void)addCurveToProjectedPoint:(RMProjectedPoint)projectedPoint
          controlProjectedPoint1:(RMProjectedPoint)controlProjectedPoint1
          controlProjectedPoint2:(RMProjectedPoint)controlProjectedPoint2;

- (void)addQuadCurveToProjectedPoint:(RMProjectedPoint)projectedPoint
               controlProjectedPoint:(RMProjectedPoint)controlProjectedPoint;
```

Mimicking the existing methods for adding lines and moving to points.
