### PR TITLE
Annotation movements synchronised with zooms

### DIFF
--- a/MapView/Map/RMMapView.h
+++ b/MapView/Map/RMMapView.h
@@ -229,6 +229,8 @@ typedef enum : NSUInteger {
 *   @param animated Whether to animate the zoom. */
 - (void)zoomByFactor:(float)zoomFactor near:(CGPoint)center animated:(BOOL)animated;
 
+- (void)zoomToRect:(CGRect)rect animated:(BOOL)animated;
+
 /** Zoom the map in at the next integral zoom level near a certain point. 
 *   @param pivot The point at which to zoom the map. 
 *   @param animated Whether to animate the zoom. */

--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -1227,7 +1227,8 @@
 
     UITapGestureRecognizer *singleTapRecognizer = [[[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleSingleTap:)] autorelease];
     singleTapRecognizer.numberOfTouchesRequired = 1;
-    [singleTapRecognizer requireGestureRecognizerToFail:doubleTapRecognizer];
+    // this line causes a ~1sec delay on annotation taps. do not want
+//    [singleTapRecognizer requireGestureRecognizerToFail:doubleTapRecognizer];
     singleTapRecognizer.delegate = self;
 
     UILongPressGestureRecognizer *longPressRecognizer = [[[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(handleLongPress:)] autorelease];

--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -321,7 +321,7 @@
 	coordinate.latitude = kDefaultInitialLatitude;
 	coordinate.longitude = kDefaultInitialLongitude;
 
-    [self performInitializationWithTilesource:[RMMapBoxSource new]
+    [self performInitializationWithTilesource:nil
                              centerCoordinate:coordinate
                                     zoomLevel:kDefaultInitialZoomLevel
                                  maxZoomLevel:kDefaultMaximumZoomLevel

--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -971,9 +971,10 @@
 
 - (void)zoomToRect:(CGRect)rect animated:(BOOL)animated {
     _ignoreZoomEvent = YES;
-    [UIView animateWithDuration:animated ? 0.3 : 0 animations:^{
+    [UIView animateWithDuration:animated ? 0.3 : 0 delay:0
+            options:UIViewAnimationOptionBeginFromCurrentState animations:^{
         [_mapScrollView zoomToRect:rect animated:NO];
-    }];
+    } completion:nil];
     [self correctPositionOfAllAnnotationsIncludingInvisibles:YES animated:animated];
     _ignoreZoomEvent = NO;
 }

--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -162,6 +162,7 @@
     CGPoint _lastContentOffset, _accumulatedDelta;
     CGSize _lastContentSize;
     BOOL _mapScrollViewIsZooming;
+    BOOL _ignoreZoomEvent;
 
     BOOL _draggingEnabled, _bouncingEnabled;
 
@@ -877,17 +878,20 @@
 
 - (void)setZoom:(float)newZoom atCoordinate:(CLLocationCoordinate2D)newCenter animated:(BOOL)animated
 {
+    _ignoreZoomEvent = YES;
     [UIView animateWithDuration:(animated ? 0.3 : 0.0)
                           delay:0.0
                         options:UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationCurveEaseInOut
                      animations:^(void)
                      {
-                         [self setZoom:newZoom];
                          [self setCenterCoordinate:newCenter animated:NO];
+                         [self setZoom:newZoom];
 
                          self.userTrackingMode = RMUserTrackingModeNone;
                      }
                      completion:nil];
+    [self correctPositionOfAllAnnotationsIncludingInvisibles:YES animated:YES];
+    _ignoreZoomEvent = NO;
 }
 
 - (void)zoomByFactor:(float)zoomFactor near:(CGPoint)pivot animated:(BOOL)animated
@@ -1272,6 +1276,10 @@
 
 - (void)scrollViewDidZoom:(UIScrollView *)scrollView
 {
+    if (_ignoreZoomEvent) {
+        return;
+    }
+
     BOOL wasUserAction = (scrollView.pinchGestureRecognizer.state == UIGestureRecognizerStateChanged);
 
     [self registerZoomEventByUser:wasUserAction];


### PR DESCRIPTION
Changes relevant to #116.

No idea why the pull request is showing a massive list of old commits (I appear to be cursed with constant git fumbles). The "files changed" is showing the right things though. 

The only changes are a slightly modified `setZoom:atCoordinate:animated:` and a new custom `zoomToRect:animated:`
