### PR TITLE
fix projected point equality test

### DIFF
--- a/MapView/Map/RMFoundation.c
+++ b/MapView/Map/RMFoundation.c
@@ -31,7 +31,7 @@
 
 bool RMProjectedPointEqualToProjectedPoint(RMProjectedPoint point1, RMProjectedPoint point2)
 {
-	return point1.x == point2.x && point2.y == point2.y;
+	return point1.x == point2.x && point1.y == point2.y;
 }
 
 bool RMProjectedRectIntersectsProjectedRect(RMProjectedRect rect1, RMProjectedRect rect2)


### PR DESCRIPTION
Previously testing y coordinate always returned true because there was point2.y == point2.y
