### PR TITLE
fix custom marker colors

### DIFF
--- a/MapView/Map/RMMarker.m
+++ b/MapView/Map/RMMarker.m
@@ -121,7 +121,7 @@
         CGFloat red, green, blue, alpha;
 
         if ([color getRed:&red green:&green blue:&blue alpha:&alpha])
-            colorHex = [NSString stringWithFormat:@"%02x%02x%02x", ((NSUInteger)red * 255), ((NSUInteger)green * 255), ((NSUInteger)blue * 255)];
+            colorHex = [NSString stringWithFormat:@"%02x%02x%02x", (NSUInteger)(red * 255), (NSUInteger)(green * 255), (NSUInteger)(blue * 255)];
     }
     
     return [self initWithMapBoxMarkerImage:symbolName tintColorHex:colorHex sizeString:sizeString];


### PR DESCRIPTION
integer cast was done on a value of range 0..1 before multiplying by 255
-> always black
