### PR TITLE
* Fixed some retain cycles that were preventing the RMMapView from deallocating

### DIFF
--- a/MapView/Map/RMAnnotation.h
+++ b/MapView/Map/RMAnnotation.h
@@ -154,6 +154,6 @@
 #pragma mark -
 
 // Used internally
-@property (nonatomic, strong) RMMapView *mapView;
+@property (nonatomic, weak) RMMapView *mapView;
 
 @end

--- a/MapView/Map/RMMapTiledLayerView.m
+++ b/MapView/Map/RMMapTiledLayerView.m
@@ -41,7 +41,7 @@
 
 @implementation RMMapTiledLayerView
 {
-    RMMapView *_mapView;
+    __weak RMMapView *_mapView;
     id <RMTileSource> _tileSource;
 }
 

--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -594,25 +594,23 @@
     {
         BOOL flag = wasUserEvent;
 
-        if ([_zoomDelegateQueue operationCount] == 0)
+        if ([_zoomDelegateQueue operationCount] == 0 && _delegateHasBeforeMapZoom)
         {
             dispatch_async(dispatch_get_main_queue(), ^(void)
             {
-                if (_delegateHasBeforeMapZoom)
-                    [_delegate beforeMapZoom:self byUser:flag];
+                [_delegate beforeMapZoom:self byUser:flag];
             });
         }
 
         [_zoomDelegateQueue setSuspended:YES];
 
-        if ([_zoomDelegateQueue operationCount] == 0)
+        if ([_zoomDelegateQueue operationCount] == 0 && _delegateHasAfterMapZoom)
         {
             [_zoomDelegateQueue addOperationWithBlock:^(void)
             {
                 dispatch_async(dispatch_get_main_queue(), ^(void)
                 {
-                    if (_delegateHasAfterMapZoom)
-                        [_delegate afterMapZoom:self byUser:flag];
+                    [_delegate afterMapZoom:self byUser:flag];
                 });
             }];
         }

--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -112,8 +112,6 @@
 
 @implementation RMMapView
 {
-    id <RMMapViewDelegate> _delegate;
-
     BOOL _delegateHasBeforeMapMove;
     BOOL _delegateHasAfterMapMove;
     BOOL _delegateHasBeforeMapZoom;
@@ -179,7 +177,7 @@
     UIImageView *_userHeadingTrackingView;
     UIImageView *_userHaloTrackingView;
 
-    UIViewController *_viewControllerPresentingAttribution;
+    __weak UIViewController *_viewControllerPresentingAttribution;
     UIButton *_attributionButton;
 
     CGAffineTransform _mapTransform;
@@ -505,11 +503,6 @@
 
 #pragma mark -
 #pragma mark Delegate
-
-- (id <RMMapViewDelegate>)delegate
-{
-	return _delegate;
-}
 
 - (void)setDelegate:(id <RMMapViewDelegate>)aDelegate
 {

--- a/MapView/Map/RMQuadTree.m
+++ b/MapView/Map/RMQuadTree.m
@@ -70,7 +70,7 @@
     NSMutableArray *_annotations;
     RMQuadTreeNode *_parentNode, *_northWest, *_northEast, *_southWest, *_southEast;
     RMQuadTreeNodeType _nodeType;
-    RMMapView *_mapView;
+    __weak RMMapView *_mapView;
 
     RMAnnotation *_cachedClusterAnnotation;
     NSArray *_cachedClusterEnclosedAnnotations;
@@ -596,7 +596,7 @@
 @implementation RMQuadTree
 {
     RMQuadTreeNode *_rootNode;
-    RMMapView *_mapView;
+    __weak RMMapView *_mapView;
 }
 
 - (id)initWithMapView:(RMMapView *)aMapView


### PR DESCRIPTION
There seem to be quite a few memory leaks caused by retain cycles. 

https://github.com/Alpstein/route-me/issues/102
https://github.com/mapbox/mapbox-ios-sdk/issues/221

I have fixed a few of these with this commit. You can reproduce the leak easily by pushing a view controller with a RMMapView onto a Navigation Controller and popping it off again.
