### PR TITLE
fixed crash on no network connection

### DIFF
--- a/MapView/Map/RMConfiguration.m
+++ b/MapView/Map/RMConfiguration.m
@@ -73,7 +73,9 @@ static RMConfiguration *RMConfigurationSharedInstance = nil;
 
     if ( ! returnData)
     {
-        *error = internalError;
+        if (error) {
+            *error = internalError;
+        }
 
         return nil;
     }

--- a/MapView/Map/RMMapBoxSource.m
+++ b/MapView/Map/RMMapBoxSource.m
@@ -164,7 +164,9 @@
 
 - (void)dealloc
 {
-    dispatch_release(_dataQueue);
+    if (_dataQueue) {
+        dispatch_release(_dataQueue);
+    }
 }
 
 #pragma mark 


### PR DESCRIPTION
Creating a RMMapView with RMMapBoxSource when there is no connection results in a nil mapview. The crash is avoided.
