### PR TITLE
BUG FIX - Attribution button not visible after a device rotation

### DIFF
--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -3534,7 +3534,8 @@
     }
     else if ( ! _viewControllerPresentingAttribution && _attributionButton)
     {
-        [_attributionButton removeFromSuperview];
+      [_attributionButton removeFromSuperview];
+      _attributionButton = nil;
     }
 }
 


### PR DESCRIPTION
When a device rotation occurs the attribution controller is set to nil. At the same time the attribution button is removed from its superview. But the attribution button is not set to nil.
If the attribution button is not set to nil after being removed from the superview it will never be re-attached, e.g. after a device orientation. And therefore, it will never become visible again.
