### PR TITLE
fixed exception on nil passed annotation

### DIFF
--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -2887,6 +2887,9 @@
 
 - (void)addAnnotation:(RMAnnotation *)annotation
 {
+    if (!annotation)
+        return;
+    
     @synchronized (_annotations)
     {
         if ([_annotations containsObject:annotation])

--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -3215,12 +3215,7 @@
         return;
 
     if ([newLocation distanceFromLocation:oldLocation])
-    {
         self.userLocation.location = newLocation;
-
-        if (_delegateHasDidUpdateUserLocation)
-            [_delegate mapView:self didUpdateUserLocation:self.userLocation];
-    }
 
     if (self.userTrackingMode != RMUserTrackingModeNone)
     {
@@ -3380,6 +3375,9 @@
 
     if ( ! [_annotations containsObject:self.userLocation])
         [self addAnnotation:self.userLocation];
+
+    if (_delegateHasDidUpdateUserLocation && [newLocation distanceFromLocation:oldLocation])
+        [_delegate mapView:self didUpdateUserLocation:self.userLocation];
 }
 
 - (BOOL)locationManagerShouldDisplayHeadingCalibration:(CLLocationManager *)manager


### PR DESCRIPTION
That exception throw cause addAnnotation: sended nil-value annotation.
This method called from locationManager:didUpdateToLocation:fromLocation:
and there sended self.userLocation. Therefore self.userLocation
is already nil.
If we look at begining of this method we see call of delegate method
didUpdateUserLocation:. There we call showsUserLocation: and if we sent
NO as param, then RMMapView set self.userLocation = nil. Therefore
self.userLocation is already nil when we call addAnnotation: in
locationManager:didUpdateToLocation:fromLocation:.
If we call delegate method after addAnnotation: it will be good, cause
it sets to nil after all usage.
