### PR TITLE
Fix RMMapBoxSource initWithMapID crash when offline

### DIFF
--- a/MapView/Map/RMAbstractWebMapSource.m
+++ b/MapView/Map/RMAbstractWebMapSource.m
@@ -84,7 +84,9 @@
     });
 
     NSArray *URLs = [self URLsForTile:tile];
-
+    if ([URLs count] == 0)
+        return nil;  // make sure there is a valid URL
+    
     if ([URLs count] > 1)
     {
         // fill up collection array with placeholders
@@ -108,7 +110,7 @@
                 {
                     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:currentURL];
                     [request setTimeoutInterval:(self.requestTimeoutSeconds / (CGFloat)self.retryCount)];
-                    tileData = [NSURLConnection sendBrandedSynchronousRequest:request returningResponse:nil error:nil];
+                    tileData = [NSURLConnection sendBrandedSynchronousRequest:request returningResponse:nil error:NULL];
                 }
 
                 if (tileData)
@@ -157,7 +159,7 @@
             NSHTTPURLResponse *response = nil;
             NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[URLs objectAtIndex:0]];
             [request setTimeoutInterval:(self.requestTimeoutSeconds / (CGFloat)self.retryCount)];
-            image = [UIImage imageWithData:[NSURLConnection sendBrandedSynchronousRequest:request returningResponse:&response error:nil]];
+            image = [UIImage imageWithData:[NSURLConnection sendBrandedSynchronousRequest:request returningResponse:&response error:NULL]];
 
             if (response.statusCode == HTTP_404_NOT_FOUND)
                 break;

--- a/MapView/Map/RMBingSource.h
+++ b/MapView/Map/RMBingSource.h
@@ -27,7 +27,7 @@
 
 #import "RMAbstractWebMapSource.h"
 
-typedef enum NSUInteger {
+typedef enum : NSUInteger {
     RMBingImagerySetRoad             = 0, // default
     RMBingImagerySetAerial           = 1,
     RMBingImagerySetAerialWithLabels = 2,

--- a/MapView/Map/RMBingSource.m
+++ b/MapView/Map/RMBingSource.m
@@ -75,7 +75,10 @@
 
         NSData *metadataData = [NSData brandedDataWithContentsOfURL:metadataURL];
 
-        id metadata = [NSJSONSerialization JSONObjectWithData:metadataData options:0 error:nil];
+        if (!metadataData)
+            return nil; // avoid crash when offline
+        
+        id metadata = [NSJSONSerialization JSONObjectWithData:metadataData options:0 error:NULL];
 
         if (metadata && [metadata isKindOfClass:[NSDictionary class]] && [[metadata objectForKey:@"statusCode"] intValue] == 200)
         {

--- a/MapView/Map/RMConfiguration.m
+++ b/MapView/Map/RMConfiguration.m
@@ -52,7 +52,7 @@ static RMConfiguration *RMConfigurationSharedInstance = nil;
 
     [request setValue:[[RMConfiguration configuration] userAgent] forHTTPHeaderField:@"User-Agent"];
 
-    return [NSURLConnection sendSynchronousRequest:request returningResponse:nil error:nil];
+    return [NSURLConnection sendSynchronousRequest:request returningResponse:nil error:NULL];
 }
 
 @end
@@ -67,16 +67,10 @@ static RMConfiguration *RMConfigurationSharedInstance = nil;
 
     [request setValue:[[RMConfiguration configuration] userAgent] forHTTPHeaderField:@"User-Agent"];
 
-    NSError *internalError = nil;
-
-    NSData *returnData = [NSURLConnection sendSynchronousRequest:request returningResponse:nil error:&internalError];
+    NSData *returnData = [NSURLConnection sendSynchronousRequest:request returningResponse:nil error:error];
 
     if ( ! returnData)
-    {
-        *error = internalError;
-
         return nil;
-    }
 
     return [[[self class] alloc] initWithData:returnData encoding:enc];
 }
@@ -117,13 +111,15 @@ static RMConfiguration *RMConfigurationSharedInstance = nil;
 
     RMLog(@"reading route-me configuration from %@", path);
 
-    NSString *error = nil;
+    NSError *error = nil;
     NSData *plistData = [NSData dataWithContentsOfFile:path];
 
+    /* deprecated method:
     _propertyList = [NSPropertyListSerialization propertyListFromData:plistData
                                                      mutabilityOption:NSPropertyListImmutable
                                                                format:NULL
-                                                     errorDescription:&error];
+                                                     errorDescription:&error]; */
+    _propertyList = [NSPropertyListSerialization propertyListWithData:plistData options:NSPropertyListImmutable format:NULL error:&error];
 
     if ( ! _propertyList)
     {

--- a/MapView/Map/RMDatabaseCache.h
+++ b/MapView/Map/RMDatabaseCache.h
@@ -28,6 +28,47 @@
 #import <UIKit/UIKit.h>
 #import "RMTileCache.h"
 
+typedef enum : NSUInteger {
+    RMDatabaseCacheImageTypePNG      = 0, // default
+    RMDatabaseCacheImageTypeJPEG     = 1
+} RMDatabaseCacheImageType;
+
+#pragma mark -
+
+@class RMDatabaseCache;
+
+/** The RMTileCacheBackgroundDelegate protocol is for receiving notifications about background tile cache download operations. */
+@protocol RMDatabaseCacheBackgroundDelegate <NSObject>
+
+@optional
+
+/** Sent when the background caching operation begins.
+ *   @param databaseCache The database cache.
+ *   @param tileCount The total number of tiles required for coverage of the desired geographic area.
+ *   @param tileSource The tile source providing the tiles.
+ *   @param identifier Arbitrary object which is provided back to the delegate to identify the download operation. */
+- (void)databaseCache:(RMDatabaseCache *)tileCache didBeginBackgroundCacheWithCount:(int)tileCount forTileSource:(id <RMTileSource>)tileSource withIdentifier:(id)identifier;
+
+/** Sent upon caching of each tile in a background cache operation.
+ *   @param databaseCache The database cache.
+ *   @param tile A structure representing the tile in question.
+ *   @param tileIndex The index of the tile in question, beginning with `1` and ending with totalTileCount.
+ *   @param totalTileCount The total number of of tiles required for coverage of the desired geographic area.
+ *   @param identifier Arbitrary object which is provided back to the delegate to identify the download operation. */
+- (void)databaseCache:(RMDatabaseCache *)tileCache didBackgroundCacheTile:(RMTile)tile withIndex:(int)tileIndex ofTotalTileCount:(int)totalTileCount withIdentifier:(id)identifier;
+
+/** Sent when all tiles have completed downloading and caching.
+ *   @param databaseCache The database cache.
+ *   @param identifier Arbitrary object which is provided back to the delegate to identify the download operation. */
+- (void)databaseCacheDidFinishBackgroundCache:(RMDatabaseCache *)tileCache withIdentifier:(id)identifier;
+
+/** Sent when the cache download operation has completed cancellation and the cache object is safe to dispose of.
+ *   @param databaseCache The database cache.
+ *   @param identifier Arbitrary object which is provided back to the delegate to identify the download operation. */
+- (void)databaseCacheDidCancelBackgroundCache:(RMDatabaseCache *)tileCache withIdentifier:(id)identifier;
+
+@end
+
 /** An RMDatabaseCache object represents disk-based caching of map tile images. This cache is meant for longer-term storage than RMMemoryCache, potentially for long periods of time, allowing completely offline use of map view.
 *
 *   @warning The database cache is currently based on [SQLite](http://www.sqlite.org), a lightweight, cross-platform, file-based relational database system. The schema is independent of and unrelated to the [MBTiles](http://mbtiles.org) file format or the RMMBTilesSource tile source. */
@@ -62,6 +103,21 @@
 *   @param theCapacity The number of tiles to allow to accumulate in the database before purging begins. */
 - (void)setCapacity:(NSUInteger)theCapacity;
 
+/** A Boolean value indicating whether the database cache is read-only: tiles will not be added or removed from the cache. Defaults to NO. */
+@property (nonatomic, assign) BOOL readOnly;
+
+/** The type of images to store in the database, can be either PNG (default) or JPEG. */
+@property (nonatomic, assign) RMDatabaseCacheImageType imageType;
+
+/** The compression factor for JPEG images stored in the database. expressed as a value from 0.0 to 1.0. 
+*   The value 0.0 represents the maximum compression (or lowest quality) while the value 1.0 represents 
+*   the least compression (or best quality). Defaults to 0.8. This parameter is ignored for PNG images. */
+@property (nonatomic, assign) CGFloat jpegQuality;
+
+- (BOOL)containsTile:(RMTile)tile withCacheKey:(NSString *)aCacheKey;
+
+- (void)addImageAndWait:(UIImage *)image forTile:(RMTile)tile withCacheKey:(NSString *)aCacheKey;
+
 /** The capacity, in number of tiles, that the database cache can hold. */
 @property (nonatomic, readonly, assign) NSUInteger capacity;
 
@@ -75,5 +131,28 @@
 
 /** The current file size of the database cache on disk. */
 - (unsigned long long)fileSize;
+
+/** @name Background Downloading */
+
+/** A delegate to notify of background tile cache download operations. */
+@property (nonatomic, weak) id <RMDatabaseCacheBackgroundDelegate>backgroundCacheDelegate;
+
+/** Whether or not the tile cache is currently background caching. */
+@property (nonatomic, readonly, assign) BOOL isBackgroundCaching;
+
+/** Tells the tile cache to begin background caching. Progress during the caching operation can be observed by implementing the RMTileCacheBackgroundDelegate protocol.
+ *   @param tileSource The tile source from which to retrieve tiles.
+ *   @param southWest The southwest corner of the geographic area to cache.
+ *   @param northEast The northeast corner of the geographic area to cache.
+ *   @param minZoom The minimum zoom level to cache.
+ *   @param maxZoom The maximum zoom level to cache. 
+ *   @param identifier Arbitrary object which will be provided back to the delegate to identify this download operation. */
+- (void)beginBackgroundCacheForTileSource:(id <RMTileSource>)tileSource southWest:(CLLocationCoordinate2D)southWest northEast:(CLLocationCoordinate2D)northEast
+                                  minZoom:(float)minZoom maxZoom:(float)maxZoom withIdentifier:(id)identifier;
+
+/** Cancel any background caching.
+ *
+ *   This method returns immediately so as to not block the calling thread. If you wish to be notified of the actual cancellation completion, implement the tileCacheDidCancelBackgroundCache: delegate method. */
+- (void)cancelBackgroundCache;
 
 @end

--- a/MapView/Map/RMDatabaseCache.m
+++ b/MapView/Map/RMDatabaseCache.m
@@ -30,6 +30,7 @@
 #import "FMDatabaseQueue.h"
 #import "RMTileImage.h"
 #import "RMTile.h"
+#import "RMDataBaseCacheDownloadOperation.h"
 
 #define kWriteQueueLimit 15
 
@@ -58,9 +59,15 @@
     NSUInteger _capacity;
     NSUInteger _minimalPurge;
     NSTimeInterval _expiryPeriod;
+
+    id <RMTileSource> _activeTileSource;
+    NSOperationQueue *_backgroundFetchQueue;
+    id _backgroundCacheIdentifier;
 }
 
-@synthesize databasePath = _databasePath;
+@synthesize databasePath                = _databasePath;
+@synthesize backgroundCacheDelegate     = _backgroundCacheDelegate;
+@synthesize readOnly                    = _readOnly;
 
 + (NSString *)dbPathUsingCacheDir:(BOOL)useCacheDir
 {
@@ -79,7 +86,7 @@
 		if ( ![[NSFileManager defaultManager] fileExistsAtPath: cachePath])
 		{
 			// create a new cache directory
-			[[NSFileManager defaultManager] createDirectoryAtPath:cachePath withIntermediateDirectories:NO attributes:nil error:nil];
+			[[NSFileManager defaultManager] createDirectoryAtPath:cachePath withIntermediateDirectories:NO attributes:nil error:NULL];
 		}
 
 		return [cachePath stringByAppendingPathComponent:@"RMTileCache.db"];
@@ -107,7 +114,16 @@
 		return nil;
 
 	self.databasePath = path;
+    self.backgroundCacheDelegate = nil;
+    self.readOnly = NO;
 
+    _activeTileSource = nil;
+    _backgroundFetchQueue = nil;
+    _backgroundCacheIdentifier = nil;
+    
+    _imageType = RMDatabaseCacheImageTypePNG;
+    _jpegQuality = 0.8;
+    
     _writeQueue = [NSOperationQueue new];
     [_writeQueue setMaxConcurrentOperationCount:1];
     _writeQueueLock = [NSRecursiveLock new];
@@ -144,6 +160,9 @@
 
 - (void)dealloc
 {
+    if (self.isBackgroundCaching)
+        [self cancelBackgroundCache];
+    
     [_writeQueueLock lock];
      _writeQueue = nil;
     [_writeQueueLock unlock];
@@ -180,7 +199,7 @@
 
 - (unsigned long long)fileSize
 {
-    return [[[NSFileManager defaultManager] attributesOfItemAtPath:self.databasePath error:nil] fileSize];
+    return [[[NSFileManager defaultManager] attributesOfItemAtPath:self.databasePath error:NULL] fileSize];
 }
 
 - (UIImage *)cachedImage:(RMTile)tile withCacheKey:(NSString *)aCacheKey
@@ -193,7 +212,7 @@
 
     [_queue inDatabase:^(FMDatabase *db)
      {
-         FMResultSet *results = [db executeQuery:@"SELECT data FROM ZCACHE WHERE tile_hash = ? AND cache_key = ?", [RMTileCache tileHash:tile], aCacheKey];
+         FMResultSet *results = [db executeQuery:@"SELECT data FROM ZCACHE WHERE tile_hash = ? AND cache_key = ? LIMIT 1", [RMTileCache tileHash:tile], aCacheKey];
 
          if ([db hadError])
          {
@@ -228,7 +247,7 @@
                  BOOL result = [db executeUpdate:@"DELETE FROM ZCACHE WHERE last_used < ?", [NSDate dateWithTimeIntervalSinceNow:-_expiryPeriod]];
 
                  if (result == NO)
-                     RMLog(@"Error expiring cache");
+                     RMLog(@"DB error while expiring cache: %@", [db lastErrorMessage]);
 
                  [[db executeQuery:@"VACUUM"] close];
              }];
@@ -244,53 +263,98 @@
 	return cachedImage;
 }
 
+- (BOOL)containsTile:(RMTile)tile withCacheKey:(NSString *)aCacheKey
+{
+    __block BOOL result = NO;
+    
+    [_writeQueueLock lock];
+    
+    [_queue inDatabase:^(FMDatabase *db)
+     {
+         FMResultSet *results = [db executeQuery:@"SELECT 1 FROM ZCACHE WHERE tile_hash = ? AND cache_key = ? LIMIT 1", [RMTileCache tileHash:tile], aCacheKey];
+         
+         if ([db hadError])
+         {
+             RMLog(@"DB error while fetching tile data: %@", [db lastErrorMessage]);
+             return;
+         }
+         
+         if ([results next])
+             result = YES;
+         
+         [results close];
+     }];
+    
+    
+    [_writeQueueLock unlock];
+    
+    return result;
+}
+
 - (void)addImage:(UIImage *)image forTile:(RMTile)tile withCacheKey:(NSString *)aCacheKey
 {
+    [self addImage:image forTile:tile withCacheKey:aCacheKey useQueue:YES];
+}
+
+- (void)addImageAndWait:(UIImage *)image forTile:(RMTile)tile withCacheKey:(NSString *)aCacheKey
+{
+    [self addImage:image forTile:tile withCacheKey:aCacheKey useQueue:NO];
+}
+
+- (void)addImage:(UIImage *)image forTile:(RMTile)tile withCacheKey:(NSString *)aCacheKey useQueue:(BOOL)useQueue
+{
+    if (self.readOnly || self.capacity == 0) return;
+
     // TODO: Converting the image here (again) is not so good...
-	NSData *data = UIImagePNGRepresentation(image);
+    NSData *data;
+    if (self.imageType == RMDatabaseCacheImageTypePNG)
+        data = UIImagePNGRepresentation(image);
+    else if (self.imageType == RMDatabaseCacheImageTypeJPEG)
+        data = UIImageJPEGRepresentation(image, self.jpegQuality);
+    
+    NSUInteger tilesInDb = [self count];
+    
+    if (_capacity <= tilesInDb && _expiryPeriod == 0)
+        [self purgeTiles:MAX(_minimalPurge, 1+tilesInDb-_capacity)];
+    
+    //        RMLog(@"DB cache     insert tile %d %d %d (%@)", tile.x, tile.y, tile.zoom, [RMTileCache tileHash:tile]);
+    
+    // Don't add new images to the database while there are still more than kWriteQueueLimit
+    // insert operations pending. This prevents some memory issues.
+    
+    BOOL skipThisTile = NO;
+    
+    [_writeQueueLock lock];
+    
+    if (useQueue && [_writeQueue operationCount] > kWriteQueueLimit) {
+        RMLog(@"RMDatabaseCache write queue limit exceeded, skipped writing tile to cache.");
+        skipThisTile = YES;
+    }
+    
+    [_writeQueueLock unlock];
+    
+    if (skipThisTile)
+        return;
 
-    if (_capacity != 0)
-    {
-        NSUInteger tilesInDb = [self count];
-
-        if (_capacity <= tilesInDb && _expiryPeriod == 0)
-            [self purgeTiles:MAX(_minimalPurge, 1+tilesInDb-_capacity)];
-
-//        RMLog(@"DB cache     insert tile %d %d %d (%@)", tile.x, tile.y, tile.zoom, [RMTileCache tileHash:tile]);
-
-        // Don't add new images to the database while there are still more than kWriteQueueLimit
-        // insert operations pending. This prevents some memory issues.
-
-        BOOL skipThisTile = NO;
-
+    void (^dbBlock) (void) = ^{
         [_writeQueueLock lock];
-
-        if ([_writeQueue operationCount] > kWriteQueueLimit)
-            skipThisTile = YES;
-
+        
+        [_queue inDatabase:^(FMDatabase *db)
+         {
+             BOOL result = [db executeUpdate:@"INSERT OR IGNORE INTO ZCACHE (tile_hash, cache_key, last_used, data) VALUES (?, ?, ?, ?)", [RMTileCache tileHash:tile], aCacheKey, [NSDate date], data];
+             if (result == NO)
+                 RMLog(@"DB error while adding tile data: %@", [db lastErrorMessage]);
+             else
+                 _tileCount++;
+         }];
+        
         [_writeQueueLock unlock];
-
-        if (skipThisTile)
-            return;
-
-        [_writeQueue addOperationWithBlock:^{
-            __block BOOL result = NO;
-
-            [_writeQueueLock lock];
-
-            [_queue inDatabase:^(FMDatabase *db)
-             {
-                 result = [db executeUpdate:@"INSERT OR IGNORE INTO ZCACHE (tile_hash, cache_key, last_used, data) VALUES (?, ?, ?, ?)", [RMTileCache tileHash:tile], aCacheKey, [NSDate date], data];
-             }];
-
-            [_writeQueueLock unlock];
-
-            if (result == NO)
-                RMLog(@"Error occured adding data");
-            else
-                _tileCount++;
-        }];
-	}
+    };
+    
+    if (useQueue)
+        [_writeQueue addOperationWithBlock:dbBlock];
+    else
+        dbBlock();
 }
 
 #pragma mark -
@@ -325,6 +389,8 @@
 
 - (void)purgeTiles:(NSUInteger)count
 {
+    if (self.readOnly) return;
+
     RMLog(@"purging %u old tiles from the db cache", count);
 
     [_writeQueueLock lock];
@@ -346,6 +412,8 @@
 
 - (void)removeAllCachedImages 
 {
+    if (self.readOnly) return;
+
     RMLog(@"removing all tiles from the db cache");
 
     [_writeQueue addOperationWithBlock:^{
@@ -369,6 +437,8 @@
 
 - (void)removeAllCachedImagesForCacheKey:(NSString *)cacheKey
 {
+    if (self.readOnly) return;
+
     RMLog(@"removing tiles for key '%@' from the db cache", cacheKey);
 
     [_writeQueue addOperationWithBlock:^{
@@ -390,6 +460,8 @@
 
 - (void)touchTile:(RMTile)tile withKey:(NSString *)cacheKey
 {
+    if (self.readOnly) return;
+
     [_writeQueue addOperationWithBlock:^{
         [_writeQueueLock lock];
 
@@ -404,6 +476,136 @@
         [_writeQueueLock unlock];
     }];
 }
+
+- (BOOL)isBackgroundCaching
+{
+    return (_activeTileSource || _backgroundFetchQueue);
+}
+
+- (void)beginBackgroundCacheForTileSource:(id <RMTileSource>)tileSource southWest:(CLLocationCoordinate2D)southWest northEast:(CLLocationCoordinate2D)northEast
+                                  minZoom:(float)minZoom maxZoom:(float)maxZoom withIdentifier:(id)identifier
+{
+    if (self.isBackgroundCaching || self.readOnly)
+        return;
+    
+    _activeTileSource = tileSource;
+    _backgroundCacheIdentifier = identifier;
+    
+    _backgroundFetchQueue = [[NSOperationQueue alloc] init];
+    [_backgroundFetchQueue setMaxConcurrentOperationCount:6];
+    
+    int   minCacheZoom = (int)minZoom;
+    int   maxCacheZoom = (int)maxZoom;
+    float minCacheLat  = southWest.latitude;
+    float maxCacheLat  = northEast.latitude;
+    float minCacheLon  = southWest.longitude;
+    float maxCacheLon  = northEast.longitude;
+    
+    if (maxCacheZoom < minCacheZoom || maxCacheLat <= minCacheLat || maxCacheLon <= minCacheLon)
+        return;
+    
+    int n, xMin, yMax, xMax, yMin;
+    
+    int totalTiles = 0;
+    
+    for (int zoom = minCacheZoom; zoom <= maxCacheZoom; zoom++)
+    {
+        n = pow(2.0, zoom);
+        xMin = floor(((minCacheLon + 180.0) / 360.0) * n);
+        yMax = floor((1.0 - (logf(tanf(minCacheLat * M_PI / 180.0) + 1.0 / cosf(minCacheLat * M_PI / 180.0)) / M_PI)) / 2.0 * n);
+        xMax = floor(((maxCacheLon + 180.0) / 360.0) * n);
+        yMin = floor((1.0 - (logf(tanf(maxCacheLat * M_PI / 180.0) + 1.0 / cosf(maxCacheLat * M_PI / 180.0)) / M_PI)) / 2.0 * n);
+        
+        totalTiles += (xMax + 1 - xMin) * (yMax + 1 - yMin);
+    }
+    
+    [_backgroundCacheDelegate databaseCache:self didBeginBackgroundCacheWithCount:totalTiles forTileSource:_activeTileSource withIdentifier:_backgroundCacheIdentifier];
+    
+    __block int progTile = 0;
+    
+    for (int zoom = minCacheZoom; zoom <= maxCacheZoom; zoom++)
+    {
+        n = pow(2.0, zoom);
+        xMin = floor(((minCacheLon + 180.0) / 360.0) * n);
+        yMax = floor((1.0 - (logf(tanf(minCacheLat * M_PI / 180.0) + 1.0 / cosf(minCacheLat * M_PI / 180.0)) / M_PI)) / 2.0 * n);
+        xMax = floor(((maxCacheLon + 180.0) / 360.0) * n);
+        yMin = floor((1.0 - (logf(tanf(maxCacheLat * M_PI / 180.0) + 1.0 / cosf(maxCacheLat * M_PI / 180.0)) / M_PI)) / 2.0 * n);
+        
+        for (int x = xMin; x <= xMax; x++)
+        {
+            for (int y = yMin; y <= yMax; y++)
+            {
+                RMDatabaseCacheDownloadOperation *operation = [[RMDatabaseCacheDownloadOperation alloc] initWithTile:RMTileMake(x, y, zoom)
+                                                                                               forTileSource:_activeTileSource
+                                                                                                  usingCache:self];
+                
+                __block RMDatabaseCacheDownloadOperation *internalOperation = operation;
+                
+                [operation setCompletionBlock:^(void)
+                 {
+                     dispatch_sync(dispatch_get_main_queue(), ^(void)
+                                   {
+                                       if ( ! [internalOperation isCancelled])
+                                       {
+                                           progTile++;
+                                           
+                                           if ( ! internalOperation.tileExisted )
+                                           {
+                                               [_backgroundCacheDelegate databaseCache:self didBackgroundCacheTile:RMTileMake(x, y, zoom)
+                                                                             withIndex:progTile ofTotalTileCount:totalTiles withIdentifier:_backgroundCacheIdentifier];
+                                           }
+                                           
+                                           if (progTile == totalTiles)
+                                           {
+                                               _backgroundFetchQueue = nil;
+                                               
+                                               _activeTileSource = nil;
+                                               
+                                               [_backgroundCacheDelegate databaseCacheDidFinishBackgroundCache:self  withIdentifier:_backgroundCacheIdentifier];
+                                           }
+                                       }
+                                       
+                                       internalOperation = nil;
+                                   });
+                 }];
+                
+                [_backgroundFetchQueue addOperation:operation];
+            }
+        }
+    };
+}
+
+- (void)cancelBackgroundCache
+{
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^(void)
+                   {
+                       @synchronized (self)
+                       {
+                           BOOL didCancel = NO;
+                           
+                           if (_backgroundFetchQueue)
+                           {
+                               [_backgroundFetchQueue cancelAllOperations];
+                               [_backgroundFetchQueue waitUntilAllOperationsAreFinished];
+                               _backgroundFetchQueue = nil;
+                               
+                               didCancel = YES;
+                           }
+                           
+                           if (_activeTileSource)
+                               _activeTileSource = nil;
+                           
+                           if (didCancel)
+                           {
+                               dispatch_sync(dispatch_get_main_queue(), ^(void)
+                                             {
+                                                 [_backgroundCacheDelegate databaseCacheDidCancelBackgroundCache:self withIdentifier:_backgroundCacheIdentifier];
+                                             });
+                           }
+                       }
+                   });
+}
+
 
 - (void)didReceiveMemoryWarning
 {

--- a/MapView/Map/RMDatabaseCacheDownloadOperation.h
+++ b/MapView/Map/RMDatabaseCacheDownloadOperation.h
@@ -1,5 +1,5 @@
 //
-//  RMTileCacheDownloadOperation.h
+//  RMDatabaseCacheDownloadOperation.h
 //
 // Copyright (c) 2008-2013, Route-Me Contributors
 // All rights reserved.
@@ -29,10 +29,13 @@
 
 #import "RMTile.h"
 #import "RMTileSource.h"
-#import "RMTileCache.h"
 
-@interface RMTileCacheDownloadOperation : NSOperation
+@class RMDatabaseCache;
 
-- (id)initWithTile:(RMTile)tile forTileSource:(id <RMTileSource>)source usingCache:(RMTileCache *)cache;
+@interface RMDatabaseCacheDownloadOperation : NSOperation
+
+@property (nonatomic, assign) BOOL tileExisted;
+
+- (id)initWithTile:(RMTile)tile forTileSource:(id <RMTileSource>)source usingCache:(RMDatabaseCache *)cache;
 
 @end

--- a/MapView/Map/RMMapBoxSource.m
+++ b/MapView/Map/RMMapBoxSource.m
@@ -82,8 +82,10 @@
 
         _infoDictionary = (NSDictionary *)[NSJSONSerialization JSONObjectWithData:[tileJSON dataUsingEncoding:NSUTF8StringEncoding]
                                                                           options:0
-                                                                            error:nil];
-
+                                                                            error:NULL];
+        if (_infoDictionary == nil)
+            return nil; // make sure we have a valid MapBox source
+        
         _tileJSON = tileJSON;
 
         id dataObject = nil;
@@ -98,7 +100,7 @@
                     
                     NSMutableString *jsonString = nil;
                     
-                    if (dataURL && (jsonString = [NSMutableString brandedStringWithContentsOfURL:dataURL encoding:NSUTF8StringEncoding error:nil]) && jsonString)
+                    if (dataURL && (jsonString = [NSMutableString brandedStringWithContentsOfURL:dataURL encoding:NSUTF8StringEncoding error:NULL]) && jsonString)
                     {
                         if ([jsonString hasPrefix:@"grid("])
                         {
@@ -108,7 +110,7 @@
                         
                         id jsonObject = nil;
                         
-                        if ((jsonObject = [NSJSONSerialization JSONObjectWithData:[jsonString dataUsingEncoding:NSUTF8StringEncoding] options:0 error:nil]) && [jsonObject isKindOfClass:[NSDictionary class]])
+                        if ((jsonObject = [NSJSONSerialization JSONObjectWithData:[jsonString dataUsingEncoding:NSUTF8StringEncoding] options:0 error:NULL]) && [jsonObject isKindOfClass:[NSDictionary class]])
                         {
                             for (NSDictionary *feature in [jsonObject objectForKey:@"features"])
                             {
@@ -158,7 +160,7 @@
                                                                                                         options:NSAnchoredSearch & NSBackwardsSearch
                                                                                                           range:NSMakeRange(0, [[referenceURL absoluteString] length])]];
     
-    if ([[referenceURL pathExtension] isEqualToString:@"json"] && (dataObject = [NSString brandedStringWithContentsOfURL:referenceURL encoding:NSUTF8StringEncoding error:nil]) && dataObject)
+    if ([[referenceURL pathExtension] isEqualToString:@"json"] && (dataObject = [NSString brandedStringWithContentsOfURL:referenceURL encoding:NSUTF8StringEncoding error:NULL]) && dataObject)
         return [self initWithTileJSON:dataObject enablingDataOnMapView:mapView];
 
     return nil;
@@ -178,7 +180,8 @@
 
 - (void)dealloc
 {
-    dispatch_release(_dataQueue);
+    if (_dataQueue) // check for proper initialization
+        dispatch_release(_dataQueue);
 }
 
 #pragma mark 

--- a/MapView/Map/RMTileCache.h
+++ b/MapView/Map/RMTileCache.h
@@ -72,36 +72,6 @@ typedef enum : short {
 
 #pragma mark -
 
-/** The RMTileCacheBackgroundDelegate protocol is for receiving notifications about background tile cache download operations. */
-@protocol RMTileCacheBackgroundDelegate <NSObject>
-
-@optional
-
-/** Sent when the background caching operation begins.
-*   @param tileCache The tile cache. 
-*   @param tileCount The total number of tiles required for coverage of the desired geographic area. 
-*   @param tileSource The tile source providing the tiles. */
-- (void)tileCache:(RMTileCache *)tileCache didBeginBackgroundCacheWithCount:(int)tileCount forTileSource:(id <RMTileSource>)tileSource;
-
-/** Sent upon caching of each tile in a background cache operation.
-*   @param tileCache The tile cache. 
-*   @param tile A structure representing the tile in question. 
-*   @param tileIndex The index of the tile in question, beginning with `1` and ending with totalTileCount. 
-*   @param totalTileCount The total number of of tiles required for coverage of the desired geographic area. */
-- (void)tileCache:(RMTileCache *)tileCache didBackgroundCacheTile:(RMTile)tile withIndex:(int)tileIndex ofTotalTileCount:(int)totalTileCount;
-
-/** Sent when all tiles have completed downloading and caching. 
-*   @param tileCache The tile cache. */
-- (void)tileCacheDidFinishBackgroundCache:(RMTileCache *)tileCache;
-
-/** Sent when the cache download operation has completed cancellation and the cache object is safe to dispose of. 
-*   @param tileCache The tile cache. */
-- (void)tileCacheDidCancelBackgroundCache:(RMTileCache *)tileCache;
-
-@end
-
-#pragma mark -
-
 /** An RMTileCache object manages memory-based and disk-based caches for map tiles that have been retrieved from the network. 
 *
 *   An RMMapView has one RMTileCache across all tile sources, which is further divided according to each tile source's uniqueTilecacheKey property in order to keep tiles separate in the cache.
@@ -141,26 +111,5 @@ typedef enum : short {
 @property (nonatomic, readonly, strong) NSArray *tileCaches;
 
 - (void)didReceiveMemoryWarning;
-
-/** @name Background Downloading */
-
-/** A delegate to notify of background tile cache download operations. */
-@property (nonatomic, weak) id <RMTileCacheBackgroundDelegate>backgroundCacheDelegate;
-
-/** Whether or not the tile cache is currently background caching. */
-@property (nonatomic, readonly, assign) BOOL isBackgroundCaching;
-
-/** Tells the tile cache to begin background caching. Progress during the caching operation can be observed by implementing the RMTileCacheBackgroundDelegate protocol.
-*   @param tileSource The tile source from which to retrieve tiles.
-*   @param southWest The southwest corner of the geographic area to cache.
-*   @param northEast The northeast corner of the geographic area to cache. 
-*   @param minZoom The minimum zoom level to cache. 
-*   @param maxZoom The maximum zoom level to cache. */
-- (void)beginBackgroundCacheForTileSource:(id <RMTileSource>)tileSource southWest:(CLLocationCoordinate2D)southWest northEast:(CLLocationCoordinate2D)northEast minZoom:(float)minZoom maxZoom:(float)maxZoom;
-
-/** Cancel any background caching. 
-*
-*   This method returns immediately so as to not block the calling thread. If you wish to be notified of the actual cancellation completion, implement the tileCacheDidCancelBackgroundCache: delegate method. */
-- (void)cancelBackgroundCache;
 
 @end

--- a/MapView/Map/RMTileCache.m
+++ b/MapView/Map/RMTileCache.m
@@ -34,8 +34,6 @@
 #import "RMConfiguration.h"
 #import "RMTileSource.h"
 
-#import "RMTileCacheDownloadOperation.h"
-
 @interface RMTileCache (Configuration)
 
 - (id <RMTileCache>)memoryCacheWithConfig:(NSDictionary *)cfg;
@@ -54,12 +52,7 @@
     NSTimeInterval _expiryPeriod;
 
     dispatch_queue_t _tileCacheQueue;
-    
-    id <RMTileSource>_activeTileSource;
-    NSOperationQueue *_backgroundFetchQueue;
 }
-
-@synthesize backgroundCacheDelegate=_backgroundCacheDelegate;
 
 - (id)initWithExpiryPeriod:(NSTimeInterval)period
 {
@@ -72,10 +65,6 @@
     _memoryCache = nil;
     _expiryPeriod = period;
     
-    _backgroundCacheDelegate = nil;
-    _activeTileSource = nil;
-    _backgroundFetchQueue = nil;
-
     id cacheCfg = [[RMConfiguration configuration] cacheConfiguration];
     if (!cacheCfg)
         cacheCfg = [NSArray arrayWithObjects:
@@ -124,9 +113,6 @@
 
 - (void)dealloc
 {
-    if (self.isBackgroundCaching)
-        [self cancelBackgroundCache];
-    
     dispatch_barrier_sync(_tileCacheQueue, ^{
          _memoryCache = nil;
          _tileCaches = nil;
@@ -243,129 +229,6 @@
         for (id<RMTileCache> cache in _tileCaches)
         {
             [cache removeAllCachedImagesForCacheKey:cacheKey];
-        }
-    });
-}
-
-- (BOOL)isBackgroundCaching
-{
-    return (_activeTileSource || _backgroundFetchQueue);
-}
-
-- (void)beginBackgroundCacheForTileSource:(id <RMTileSource>)tileSource southWest:(CLLocationCoordinate2D)southWest northEast:(CLLocationCoordinate2D)northEast minZoom:(float)minZoom maxZoom:(float)maxZoom
-{
-    if (self.isBackgroundCaching)
-        return;
-
-    _activeTileSource = tileSource;
-    
-    _backgroundFetchQueue = [[NSOperationQueue alloc] init];
-    [_backgroundFetchQueue setMaxConcurrentOperationCount:6];
-    
-    int   minCacheZoom = (int)minZoom;
-    int   maxCacheZoom = (int)maxZoom;
-    float minCacheLat  = southWest.latitude;
-    float maxCacheLat  = northEast.latitude;
-    float minCacheLon  = southWest.longitude;
-    float maxCacheLon  = northEast.longitude;
-
-    if (maxCacheZoom < minCacheZoom || maxCacheLat <= minCacheLat || maxCacheLon <= minCacheLon)
-        return;
-
-    int n, xMin, yMax, xMax, yMin;
-
-    int totalTiles = 0;
-
-    for (int zoom = minCacheZoom; zoom <= maxCacheZoom; zoom++)
-    {
-        n = pow(2.0, zoom);
-        xMin = floor(((minCacheLon + 180.0) / 360.0) * n);
-        yMax = floor((1.0 - (logf(tanf(minCacheLat * M_PI / 180.0) + 1.0 / cosf(minCacheLat * M_PI / 180.0)) / M_PI)) / 2.0 * n);
-        xMax = floor(((maxCacheLon + 180.0) / 360.0) * n);
-        yMin = floor((1.0 - (logf(tanf(maxCacheLat * M_PI / 180.0) + 1.0 / cosf(maxCacheLat * M_PI / 180.0)) / M_PI)) / 2.0 * n);
-
-        totalTiles += (xMax + 1 - xMin) * (yMax + 1 - yMin);
-    }
-
-    [_backgroundCacheDelegate tileCache:self didBeginBackgroundCacheWithCount:totalTiles forTileSource:_activeTileSource];
-
-    __block int progTile = 0;
-
-    for (int zoom = minCacheZoom; zoom <= maxCacheZoom; zoom++)
-    {
-        n = pow(2.0, zoom);
-        xMin = floor(((minCacheLon + 180.0) / 360.0) * n);
-        yMax = floor((1.0 - (logf(tanf(minCacheLat * M_PI / 180.0) + 1.0 / cosf(minCacheLat * M_PI / 180.0)) / M_PI)) / 2.0 * n);
-        xMax = floor(((maxCacheLon + 180.0) / 360.0) * n);
-        yMin = floor((1.0 - (logf(tanf(maxCacheLat * M_PI / 180.0) + 1.0 / cosf(maxCacheLat * M_PI / 180.0)) / M_PI)) / 2.0 * n);
-
-        for (int x = xMin; x <= xMax; x++)
-        {
-            for (int y = yMin; y <= yMax; y++)
-            {
-                RMTileCacheDownloadOperation *operation = [[RMTileCacheDownloadOperation alloc] initWithTile:RMTileMake(x, y, zoom)
-                                                                                                forTileSource:_activeTileSource
-                                                                                                   usingCache:self];
-
-                __block RMTileCacheDownloadOperation *internalOperation = operation;
-
-                [operation setCompletionBlock:^(void)
-                {
-                    dispatch_sync(dispatch_get_main_queue(), ^(void)
-                    {
-                        if ( ! [internalOperation isCancelled])
-                        {
-                            progTile++;
-
-                            [_backgroundCacheDelegate tileCache:self didBackgroundCacheTile:RMTileMake(x, y, zoom) withIndex:progTile ofTotalTileCount:totalTiles];
-
-                            if (progTile == totalTiles)
-                            {
-                                 _backgroundFetchQueue = nil;
-
-                                 _activeTileSource = nil;
-
-                                [_backgroundCacheDelegate tileCacheDidFinishBackgroundCache:self];
-                            }
-                        }
-
-                        internalOperation = nil;
-                    });
-                }];
-
-                [_backgroundFetchQueue addOperation:operation];
-            }
-        }
-    };
-}
-
-- (void)cancelBackgroundCache
-{
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^(void)
-    {
-        @synchronized (self)
-        {
-            BOOL didCancel = NO;
-
-            if (_backgroundFetchQueue)
-            {
-                [_backgroundFetchQueue cancelAllOperations];
-                [_backgroundFetchQueue waitUntilAllOperationsAreFinished];
-                 _backgroundFetchQueue = nil;
-
-                didCancel = YES;
-            }
-
-            if (_activeTileSource)
-                 _activeTileSource = nil;
-
-            if (didCancel)
-            {
-                dispatch_sync(dispatch_get_main_queue(), ^(void)
-                {
-                    [_backgroundCacheDelegate tileCacheDidCancelBackgroundCache:self];
-                });
-            }
         }
     });
 }

--- a/MapView/MapView.xcodeproj/project.pbxproj
+++ b/MapView/MapView.xcodeproj/project.pbxproj
@@ -105,8 +105,8 @@
 		DD3BEF7A15913C55007892D8 /* RMAttributionViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = DD3BEF7815913C55007892D8 /* RMAttributionViewController.m */; };
 		DD4195C9162356900049E6BA /* RMBingSource.h in Headers */ = {isa = PBXBuildFile; fileRef = DD4195C7162356900049E6BA /* RMBingSource.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD4195CA162356900049E6BA /* RMBingSource.m in Sources */ = {isa = PBXBuildFile; fileRef = DD4195C8162356900049E6BA /* RMBingSource.m */; };
-		DD41960116250ED40049E6BA /* RMTileCacheDownloadOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = DD4195FF16250ED40049E6BA /* RMTileCacheDownloadOperation.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		DD41960216250ED40049E6BA /* RMTileCacheDownloadOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = DD41960016250ED40049E6BA /* RMTileCacheDownloadOperation.m */; };
+		DD41960116250ED40049E6BA /* RMDatabaseCacheDownloadOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = DD4195FF16250ED40049E6BA /* RMDatabaseCacheDownloadOperation.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		DD41960216250ED40049E6BA /* RMDatabaseCacheDownloadOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = DD41960016250ED40049E6BA /* RMDatabaseCacheDownloadOperation.m */; };
 		DD41961F16263E400049E6BA /* libGRMustache5-iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DD41961E16263E400049E6BA /* libGRMustache5-iOS.a */; };
 		DD4BE198161CE296003EF677 /* MapBox.h in Headers */ = {isa = PBXBuildFile; fileRef = DD4BE197161CE296003EF677 /* MapBox.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DD5A200B15CAD09400FE4157 /* GRMustache.h in Headers */ = {isa = PBXBuildFile; fileRef = DD5A200A15CAD09400FE4157 /* GRMustache.h */; };
@@ -265,8 +265,8 @@
 		DD3BEF7815913C55007892D8 /* RMAttributionViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RMAttributionViewController.m; sourceTree = "<group>"; };
 		DD4195C7162356900049E6BA /* RMBingSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RMBingSource.h; sourceTree = "<group>"; };
 		DD4195C8162356900049E6BA /* RMBingSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RMBingSource.m; sourceTree = "<group>"; };
-		DD4195FF16250ED40049E6BA /* RMTileCacheDownloadOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RMTileCacheDownloadOperation.h; sourceTree = "<group>"; };
-		DD41960016250ED40049E6BA /* RMTileCacheDownloadOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RMTileCacheDownloadOperation.m; sourceTree = "<group>"; };
+		DD4195FF16250ED40049E6BA /* RMDatabaseCacheDownloadOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RMDatabaseCacheDownloadOperation.h; sourceTree = "<group>"; };
+		DD41960016250ED40049E6BA /* RMDatabaseCacheDownloadOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RMDatabaseCacheDownloadOperation.m; sourceTree = "<group>"; };
 		DD41961E16263E400049E6BA /* libGRMustache5-iOS.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libGRMustache5-iOS.a"; path = "GRMustache/lib/libGRMustache5-iOS.a"; sourceTree = "<group>"; };
 		DD4BE197161CE296003EF677 /* MapBox.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MapBox.h; sourceTree = "<group>"; };
 		DD5A200A15CAD09400FE4157 /* GRMustache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GRMustache.h; path = GRMustache/include/GRMustache.h; sourceTree = "<group>"; };
@@ -435,8 +435,8 @@
 				16EC85D1133CA6C300219947 /* RMCacheObject.m */,
 				B83E64D00E80E73F001663B6 /* RMTileCache.h */,
 				B83E64D10E80E73F001663B6 /* RMTileCache.m */,
-				DD4195FF16250ED40049E6BA /* RMTileCacheDownloadOperation.h */,
-				DD41960016250ED40049E6BA /* RMTileCacheDownloadOperation.m */,
+				DD4195FF16250ED40049E6BA /* RMDatabaseCacheDownloadOperation.h */,
+				DD41960016250ED40049E6BA /* RMDatabaseCacheDownloadOperation.m */,
 				B83E64D20E80E73F001663B6 /* RMMemoryCache.h */,
 				B83E64D30E80E73F001663B6 /* RMMemoryCache.m */,
 				B8474B980EB40094006A0BC1 /* RMDatabaseCache.h */,
@@ -719,7 +719,7 @@
 				161E563A1594664E00B00BB6 /* RMOpenSeaMapLayer.h in Headers */,
 				1656665515A1DF7900EF3DC7 /* RMCoordinateGridSource.h in Headers */,
 				DD5FA1EB15E2B020004EB6C5 /* RMLoadingTileView.h in Headers */,
-				DD41960116250ED40049E6BA /* RMTileCacheDownloadOperation.h in Headers */,
+				DD41960116250ED40049E6BA /* RMDatabaseCacheDownloadOperation.h in Headers */,
 				DD4195C9162356900049E6BA /* RMBingSource.h in Headers */,
 				DD2B374514CF8041008DE8CB /* FMDatabase.h in Headers */,
 				DD2B374714CF8041008DE8CB /* FMDatabaseAdditions.h in Headers */,
@@ -878,7 +878,7 @@
 				1656665615A1DF7900EF3DC7 /* RMCoordinateGridSource.m in Sources */,
 				16E5A63B15E531F200C92A5A /* RMCompositeSource.m in Sources */,
 				DD5FA1EC15E2B020004EB6C5 /* RMLoadingTileView.m in Sources */,
-				DD41960216250ED40049E6BA /* RMTileCacheDownloadOperation.m in Sources */,
+				DD41960216250ED40049E6BA /* RMDatabaseCacheDownloadOperation.m in Sources */,
 				DD4195CA162356900049E6BA /* RMBingSource.m in Sources */,
 				DD1E3C6F161F954F004FC649 /* SMCalloutView.m in Sources */,
 				DD7C7E39164C894F0021CCA5 /* RMStaticMapView.m in Sources */,


### PR DESCRIPTION
This change fixes `RMMapboxSource` `initWithMapID:` functions crashing when the user is offline (https://github.com/mapbox/mapbox-ios-sdk/issues/259). These init methods will now return nil instead, if the user is offline.

Also included in the pull request are NSError parameters which are changed from nil to NULL (https://github.com/mapbox/mapbox-ios-sdk/issues/287), and a replacement for the deprecated `NSPropertyListSerialization propertyListFromData` call.
