### PR TITLE
Fix RMMapBoxSource initWithMapID crash when offline

### DIFF
--- a/MapView/Map/RMConfiguration.m
+++ b/MapView/Map/RMConfiguration.m
@@ -52,7 +52,7 @@ static RMConfiguration *RMConfigurationSharedInstance = nil;
 
     [request setValue:[[RMConfiguration configuration] userAgent] forHTTPHeaderField:@"User-Agent"];
 
-    return [NSURLConnection sendSynchronousRequest:request returningResponse:nil error:nil];
+    return [NSURLConnection sendSynchronousRequest:request returningResponse:nil error:NULL];
 }
 
 @end
@@ -67,16 +67,10 @@ static RMConfiguration *RMConfigurationSharedInstance = nil;
 
     [request setValue:[[RMConfiguration configuration] userAgent] forHTTPHeaderField:@"User-Agent"];
 
-    NSError *internalError = nil;
-
-    NSData *returnData = [NSURLConnection sendSynchronousRequest:request returningResponse:nil error:&internalError];
+    NSData *returnData = [NSURLConnection sendSynchronousRequest:request returningResponse:nil error:error];
 
     if ( ! returnData)
-    {
-        *error = internalError;
-
         return nil;
-    }
 
     return [[[self class] alloc] initWithData:returnData encoding:enc];
 }
@@ -117,13 +111,15 @@ static RMConfiguration *RMConfigurationSharedInstance = nil;
 
     RMLog(@"reading route-me configuration from %@", path);
 
-    NSString *error = nil;
+    NSError *error = nil;
     NSData *plistData = [NSData dataWithContentsOfFile:path];
 
+    /* deprecated method:
     _propertyList = [NSPropertyListSerialization propertyListFromData:plistData
                                                      mutabilityOption:NSPropertyListImmutable
                                                                format:NULL
-                                                     errorDescription:&error];
+                                                     errorDescription:&error]; */
+    _propertyList = [NSPropertyListSerialization propertyListWithData:plistData options:NSPropertyListImmutable format:NULL error:&error];
 
     if ( ! _propertyList)
     {

--- a/MapView/Map/RMMapBoxSource.m
+++ b/MapView/Map/RMMapBoxSource.m
@@ -82,8 +82,10 @@
 
         _infoDictionary = (NSDictionary *)[NSJSONSerialization JSONObjectWithData:[tileJSON dataUsingEncoding:NSUTF8StringEncoding]
                                                                           options:0
-                                                                            error:nil];
-
+                                                                            error:NULL];
+        if (_infoDictionary == nil)
+            return nil; // make sure we have a valid MapBox source
+        
         _tileJSON = tileJSON;
 
         id dataObject = nil;
@@ -98,7 +100,7 @@
                     
                     NSMutableString *jsonString = nil;
                     
-                    if (dataURL && (jsonString = [NSMutableString brandedStringWithContentsOfURL:dataURL encoding:NSUTF8StringEncoding error:nil]) && jsonString)
+                    if (dataURL && (jsonString = [NSMutableString brandedStringWithContentsOfURL:dataURL encoding:NSUTF8StringEncoding error:NULL]) && jsonString)
                     {
                         if ([jsonString hasPrefix:@"grid("])
                         {
@@ -108,7 +110,7 @@
                         
                         id jsonObject = nil;
                         
-                        if ((jsonObject = [NSJSONSerialization JSONObjectWithData:[jsonString dataUsingEncoding:NSUTF8StringEncoding] options:0 error:nil]) && [jsonObject isKindOfClass:[NSDictionary class]])
+                        if ((jsonObject = [NSJSONSerialization JSONObjectWithData:[jsonString dataUsingEncoding:NSUTF8StringEncoding] options:0 error:NULL]) && [jsonObject isKindOfClass:[NSDictionary class]])
                         {
                             for (NSDictionary *feature in [jsonObject objectForKey:@"features"])
                             {
@@ -158,7 +160,7 @@
                                                                                                         options:NSAnchoredSearch & NSBackwardsSearch
                                                                                                           range:NSMakeRange(0, [[referenceURL absoluteString] length])]];
     
-    if ([[referenceURL pathExtension] isEqualToString:@"json"] && (dataObject = [NSString brandedStringWithContentsOfURL:referenceURL encoding:NSUTF8StringEncoding error:nil]) && dataObject)
+    if ([[referenceURL pathExtension] isEqualToString:@"json"] && (dataObject = [NSString brandedStringWithContentsOfURL:referenceURL encoding:NSUTF8StringEncoding error:NULL]) && dataObject)
         return [self initWithTileJSON:dataObject enablingDataOnMapView:mapView];
 
     return nil;
@@ -178,7 +180,8 @@
 
 - (void)dealloc
 {
-    dispatch_release(_dataQueue);
+    if (_dataQueue) // check for proper initialization
+        dispatch_release(_dataQueue);
 }
 
 #pragma mark 


### PR DESCRIPTION
This pull request is a duplicate of pull request https://github.com/mapbox/mapbox-ios-sdk/pull/288, now opened on a dedicated branch.

This change fixes `RMMapboxSource` `initWithMapID:` functions crashing when the user is offline (issue https://github.com/mapbox/mapbox-ios-sdk/issues/259). These init methods will now return nil instead, if the user is offline.

There are two other pull requests which fix this issue: https://github.com/mapbox/mapbox-ios-sdk/pull/255 and https://github.com/mapbox/mapbox-ios-sdk/pull/267. However, these do not check `_infoDictionary` agains `nil` in `initWithTileJSON`.

Also included in the pull request are `NSError` parameters which are changed from `nil` to `NULL` (https://github.com/mapbox/mapbox-ios-sdk/issues/287), and a replacement for the deprecated `NSPropertyListSerialization propertyListFromData` call.
