### PR TITLE
Fix crash in RMBingSource when the user is offline

### DIFF
--- a/MapView/Map/RMAbstractWebMapSource.m
+++ b/MapView/Map/RMAbstractWebMapSource.m
@@ -84,7 +84,9 @@
     });
 
     NSArray *URLs = [self URLsForTile:tile];
-
+    if ([URLs count] == 0)
+        return nil;  // make sure there is a valid URL
+    
     if ([URLs count] > 1)
     {
         // fill up collection array with placeholders
@@ -108,7 +110,7 @@
                 {
                     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:currentURL];
                     [request setTimeoutInterval:(self.requestTimeoutSeconds / (CGFloat)self.retryCount)];
-                    tileData = [NSURLConnection sendBrandedSynchronousRequest:request returningResponse:nil error:nil];
+                    tileData = [NSURLConnection sendBrandedSynchronousRequest:request returningResponse:nil error:NULL];
                 }
 
                 if (tileData)
@@ -157,7 +159,7 @@
             NSHTTPURLResponse *response = nil;
             NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[URLs objectAtIndex:0]];
             [request setTimeoutInterval:(self.requestTimeoutSeconds / (CGFloat)self.retryCount)];
-            image = [UIImage imageWithData:[NSURLConnection sendBrandedSynchronousRequest:request returningResponse:&response error:nil]];
+            image = [UIImage imageWithData:[NSURLConnection sendBrandedSynchronousRequest:request returningResponse:&response error:NULL]];
 
             if (response.statusCode == HTTP_404_NOT_FOUND)
                 break;

--- a/MapView/Map/RMBingSource.h
+++ b/MapView/Map/RMBingSource.h
@@ -27,7 +27,7 @@
 
 #import "RMAbstractWebMapSource.h"
 
-typedef enum NSUInteger {
+typedef enum : NSUInteger {
     RMBingImagerySetRoad             = 0, // default
     RMBingImagerySetAerial           = 1,
     RMBingImagerySetAerialWithLabels = 2,

--- a/MapView/Map/RMBingSource.m
+++ b/MapView/Map/RMBingSource.m
@@ -75,7 +75,10 @@
 
         NSData *metadataData = [NSData brandedDataWithContentsOfURL:metadataURL];
 
-        id metadata = [NSJSONSerialization JSONObjectWithData:metadataData options:0 error:nil];
+        if (!metadataData)
+            return nil; // avoid crash when offline
+        
+        id metadata = [NSJSONSerialization JSONObjectWithData:metadataData options:0 error:NULL];
 
         if (metadata && [metadata isKindOfClass:[NSDictionary class]] && [[metadata objectForKey:@"statusCode"] intValue] == 200)
         {


### PR DESCRIPTION
These changes fix a crash in `RMBingSource` when the user is offline. 

Also included in the pull request are `NSError` parameters which are changed from `nil` to `NULL` (https://github.com/mapbox/mapbox-ios-sdk/issues/287), and a typo fix in a `typedef` declaration in `RMBingSource.h`
