### PR TITLE
Moved background caching from RMTileCache to RMDatabaseCache

### DIFF
--- a/MapView/Map/RMDatabaseCache.h
+++ b/MapView/Map/RMDatabaseCache.h
@@ -71,7 +71,11 @@ typedef enum : NSUInteger {
 
 /** An RMDatabaseCache object represents disk-based caching of map tile images. This cache is meant for longer-term storage than RMMemoryCache, potentially for long periods of time, allowing completely offline use of map view.
 *
-*   @warning The database cache is currently based on [SQLite](http://www.sqlite.org), a lightweight, cross-platform, file-based relational database system. The schema is independent of and unrelated to the [MBTiles](http://mbtiles.org) file format or the RMMBTilesSource tile source. */
+*   @warning The database cache is currently based on [SQLite](http://www.sqlite.org), a lightweight, cross-platform, file-based relational database system. The schema is independent of and unrelated to the [MBTiles](http://mbtiles.org) file format or the RMMBTilesSource tile source. 
+*
+*   An RMDatabaseCache is a key component of offline map use. Tile requests can be served from the database cache if available, avoiding network operation. If tiles exist in the cache already, a tile source that is instantiated when offline will still be able to serve tile imagery to the map renderer for areas that have been previously cached. This can occur either from normal map use, by setting the readOnly property to NO and adding the database cache to an RMMapView's tileCache, or from proactive caching ahead of time using the beginBackgroundCacheForTileSource:southWest:northEast:minZoom:maxZoom:withIdentifier: method.
+*
+*/
 @interface RMDatabaseCache : NSObject <RMTileCache>
 
 /** @name Getting the Database Path */

--- a/MapView/Map/RMDatabaseCache.h
+++ b/MapView/Map/RMDatabaseCache.h
@@ -28,6 +28,47 @@
 #import <UIKit/UIKit.h>
 #import "RMTileCache.h"
 
+typedef enum : NSUInteger {
+    RMDatabaseCacheImageTypePNG      = 0, // default
+    RMDatabaseCacheImageTypeJPEG     = 1
+} RMDatabaseCacheImageType;
+
+#pragma mark -
+
+@class RMDatabaseCache;
+
+/** The RMTileCacheBackgroundDelegate protocol is for receiving notifications about background tile cache download operations. */
+@protocol RMDatabaseCacheBackgroundDelegate <NSObject>
+
+@optional
+
+/** Sent when the background caching operation begins.
+ *   @param databaseCache The database cache.
+ *   @param tileCount The total number of tiles required for coverage of the desired geographic area.
+ *   @param tileSource The tile source providing the tiles.
+ *   @param identifier Arbitrary object which is provided back to the delegate to identify the download operation. */
+- (void)databaseCache:(RMDatabaseCache *)tileCache didBeginBackgroundCacheWithCount:(int)tileCount forTileSource:(id <RMTileSource>)tileSource withIdentifier:(id)identifier;
+
+/** Sent upon caching of each tile in a background cache operation.
+ *   @param databaseCache The database cache.
+ *   @param tile A structure representing the tile in question.
+ *   @param tileIndex The index of the tile in question, beginning with `1` and ending with totalTileCount.
+ *   @param totalTileCount The total number of of tiles required for coverage of the desired geographic area.
+ *   @param identifier Arbitrary object which is provided back to the delegate to identify the download operation. */
+- (void)databaseCache:(RMDatabaseCache *)tileCache didBackgroundCacheTile:(RMTile)tile withIndex:(int)tileIndex ofTotalTileCount:(int)totalTileCount withIdentifier:(id)identifier;
+
+/** Sent when all tiles have completed downloading and caching.
+ *   @param databaseCache The database cache.
+ *   @param identifier Arbitrary object which is provided back to the delegate to identify the download operation. */
+- (void)databaseCacheDidFinishBackgroundCache:(RMDatabaseCache *)tileCache withIdentifier:(id)identifier;
+
+/** Sent when the cache download operation has completed cancellation and the cache object is safe to dispose of.
+ *   @param databaseCache The database cache.
+ *   @param identifier Arbitrary object which is provided back to the delegate to identify the download operation. */
+- (void)databaseCacheDidCancelBackgroundCache:(RMDatabaseCache *)tileCache withIdentifier:(id)identifier;
+
+@end
+
 /** An RMDatabaseCache object represents disk-based caching of map tile images. This cache is meant for longer-term storage than RMMemoryCache, potentially for long periods of time, allowing completely offline use of map view.
 *
 *   @warning The database cache is currently based on [SQLite](http://www.sqlite.org), a lightweight, cross-platform, file-based relational database system. The schema is independent of and unrelated to the [MBTiles](http://mbtiles.org) file format or the RMMBTilesSource tile source. */
@@ -62,6 +103,21 @@
 *   @param theCapacity The number of tiles to allow to accumulate in the database before purging begins. */
 - (void)setCapacity:(NSUInteger)theCapacity;
 
+/** A Boolean value indicating whether the database cache is read-only: tiles will not be added or removed from the cache. Defaults to NO. */
+@property (nonatomic, assign) BOOL readOnly;
+
+/** The type of images to store in the database, can be either PNG (default) or JPEG. */
+@property (nonatomic, assign) RMDatabaseCacheImageType imageType;
+
+/** The compression factor for JPEG images stored in the database. expressed as a value from 0.0 to 1.0. 
+*   The value 0.0 represents the maximum compression (or lowest quality) while the value 1.0 represents 
+*   the least compression (or best quality). Defaults to 0.8. This parameter is ignored for PNG images. */
+@property (nonatomic, assign) CGFloat jpegQuality;
+
+- (BOOL)containsTile:(RMTile)tile withCacheKey:(NSString *)aCacheKey;
+
+- (void)addImageAndWait:(UIImage *)image forTile:(RMTile)tile withCacheKey:(NSString *)aCacheKey;
+
 /** The capacity, in number of tiles, that the database cache can hold. */
 @property (nonatomic, readonly, assign) NSUInteger capacity;
 
@@ -75,5 +131,28 @@
 
 /** The current file size of the database cache on disk. */
 - (unsigned long long)fileSize;
+
+/** @name Background Downloading */
+
+/** A delegate to notify of background tile cache download operations. */
+@property (nonatomic, weak) id <RMDatabaseCacheBackgroundDelegate>backgroundCacheDelegate;
+
+/** Whether or not the tile cache is currently background caching. */
+@property (nonatomic, readonly, assign) BOOL isBackgroundCaching;
+
+/** Tells the tile cache to begin background caching. Progress during the caching operation can be observed by implementing the RMTileCacheBackgroundDelegate protocol.
+ *   @param tileSource The tile source from which to retrieve tiles.
+ *   @param southWest The southwest corner of the geographic area to cache.
+ *   @param northEast The northeast corner of the geographic area to cache.
+ *   @param minZoom The minimum zoom level to cache.
+ *   @param maxZoom The maximum zoom level to cache. 
+ *   @param identifier Arbitrary object which will be provided back to the delegate to identify this download operation. */
+- (void)beginBackgroundCacheForTileSource:(id <RMTileSource>)tileSource southWest:(CLLocationCoordinate2D)southWest northEast:(CLLocationCoordinate2D)northEast
+                                  minZoom:(float)minZoom maxZoom:(float)maxZoom withIdentifier:(id)identifier;
+
+/** Cancel any background caching.
+ *
+ *   This method returns immediately so as to not block the calling thread. If you wish to be notified of the actual cancellation completion, implement the tileCacheDidCancelBackgroundCache: delegate method. */
+- (void)cancelBackgroundCache;
 
 @end

--- a/MapView/Map/RMDatabaseCacheDownloadOperation.h
+++ b/MapView/Map/RMDatabaseCacheDownloadOperation.h
@@ -1,5 +1,5 @@
 //
-//  RMTileCacheDownloadOperation.h
+//  RMDatabaseCacheDownloadOperation.h
 //
 // Copyright (c) 2008-2013, Route-Me Contributors
 // All rights reserved.
@@ -29,10 +29,13 @@
 
 #import "RMTile.h"
 #import "RMTileSource.h"
-#import "RMTileCache.h"
 
-@interface RMTileCacheDownloadOperation : NSOperation
+@class RMDatabaseCache;
 
-- (id)initWithTile:(RMTile)tile forTileSource:(id <RMTileSource>)source usingCache:(RMTileCache *)cache;
+@interface RMDatabaseCacheDownloadOperation : NSOperation
+
+@property (nonatomic, assign) BOOL tileExisted;
+
+- (id)initWithTile:(RMTile)tile forTileSource:(id <RMTileSource>)source usingCache:(RMDatabaseCache *)cache;
 
 @end

--- a/MapView/Map/RMMapView.h
+++ b/MapView/Map/RMMapView.h
@@ -147,9 +147,34 @@ typedef enum : NSUInteger {
 *   @return An initialized map view, or `nil` if the map view was unable to be initialized. */
 - (id)initWithFrame:(CGRect)frame andTilesource:(id <RMTileSource>)newTilesource;
 
-/** Designated initializer. Initialize a map view. 
+/** Initialize a map view with a given frame, tile source and tile cache.
+ *   @param frame The frame with which to initialize the map view.
+ *   @param newTilesource The tile source to use for the map tiles.
+ *   @param tileCache The tile cache to use for the map tiles.
+ *   @return An initialized map view, or `nil` if the map view was unable to be initialized. */
+- (id)initWithFrame:(CGRect)frame tilesource:(id <RMTileSource>)newTilesource andTileCache:(RMTileCache *)tileCache;
+
+/** Initialize a map view with a given frame, tile source, coordinates and zoom parameters.
+*   @param frame The map view's frame.
+*   @param newTilesource A tile source to use for the map tiles.
+*   @param initialCenterCoordinate The starting map center coordinate.
+*   @param initialTileSourceZoomLevel The starting map zoom level, clamped to the zoom levels supported by the tile source(s).
+*   @param initialTileSourceMaxZoomLevel The maximum zoom level allowed by the map view, clamped to the zoom levels supported by the tile source(s).
+*   @param initialTileSourceMinZoomLevel The minimum zoom level allowed by the map view, clamped to the zoom levels supported by the tile source(s).
+*   @param backgroundImage A custom background image to use behind the map instead of the default gridded tile background that moves with the map.
+*   @return An initialized map view, or `nil` if a map view was unable to be initialized. */
+- (id)initWithFrame:(CGRect)frame
+         tilesource:(id <RMTileSource>)newTilesource
+   centerCoordinate:(CLLocationCoordinate2D)initialCenterCoordinate
+          zoomLevel:(float)initialTileSourceZoomLevel
+       maxZoomLevel:(float)initialTileSourceMaxZoomLevel
+       minZoomLevel:(float)initialTileSourceMinZoomLevel
+    backgroundImage:(UIImage *)backgroundImage;
+
+/** Designated initializer. Initialize a map view with a given frame, tile source, tile cache, coordinates and zoom parameters.
 *   @param frame The map view's frame. 
 *   @param newTilesource A tile source to use for the map tiles. 
+*   @param tileCache The tile cache to use for the map tiles.
 *   @param initialCenterCoordinate The starting map center coordinate.
 *   @param initialTileSourceZoomLevel The starting map zoom level, clamped to the zoom levels supported by the tile source(s).
 *   @param initialTileSourceMaxZoomLevel The maximum zoom level allowed by the map view, clamped to the zoom levels supported by the tile source(s).
@@ -157,7 +182,8 @@ typedef enum : NSUInteger {
 *   @param backgroundImage A custom background image to use behind the map instead of the default gridded tile background that moves with the map. 
 *   @return An initialized map view, or `nil` if a map view was unable to be initialized. */
 - (id)initWithFrame:(CGRect)frame
-      andTilesource:(id <RMTileSource>)newTilesource
+         tilesource:(id <RMTileSource>)newTilesource
+       andTileCache:(RMTileCache *)tileCache
    centerCoordinate:(CLLocationCoordinate2D)initialCenterCoordinate
           zoomLevel:(float)initialTileSourceZoomLevel
        maxZoomLevel:(float)initialTileSourceMaxZoomLevel
@@ -390,6 +416,9 @@ typedef enum : NSUInteger {
 /** Remove the tile source at a given index from the map view. 
 *   @param index The index of the tile source to remove. */
 - (void)removeTileSourceAtIndex:(NSUInteger)index;
+
+/** Remove all tile sources from the map view. */
+- (void)removeAllTileSources;
 
 /** Move the tile source at one index to another index. 
 *   @param fromIndex The index of the tile source to move. 

--- a/MapView/Map/RMTileCache.h
+++ b/MapView/Map/RMTileCache.h
@@ -83,11 +83,38 @@ typedef enum : short {
 
 /** Initializes and returns a newly allocated cache object with specified expiry period.
 *
+*   The internal memory-based and disk-based caches will be initialized to default settings or according to a Route-Me property list included as a resource in your project. See "File-based cache configuration" in the SDK Guide for details.
+*
 *   If the `init` method is used to initialize a cache instead, a period of `0` is used. In that case, time-based expiration of tiles is not performed, but rather the cached tile count is used instead.
 *
 *   @param period A period of time after which tiles should be expunged from the cache.
 *   @return An initialized cache object or `nil` if the object couldn't be created. */
 - (id)initWithExpiryPeriod:(NSTimeInterval)period;
+
+/** Initializes and returns a newly allocated cache object with the supplied tile caches.
+ *
+ *  The internal memory cache will be initialized with a default size and the expiry period is set to `0`
+ *
+ *   @param caches An array containing memory-based or disk-based caches implementing the `RMTileCache` protocol.
+ *   @return An initialized cache object or `nil` if the object couldn't be created. */
+- (id)initWithCaches:(NSArray *)caches;
+
+/** Initializes and returns a newly allocated cache object with the supplied tile caches and expiry period.
+ *
+ *  The internal memory cache will be initialized with a default size.
+ *
+ *   @param caches An array containing memory-based or disk-based caches implementing the `RMTileCache` protocol.
+ *   @param period A period of time after which tiles should be expunged from the cache.
+ *   @return An initialized cache object or `nil` if the object couldn't be created. */
+- (id)initWithCaches:(NSArray *)caches andExpiryPeriod:(NSTimeInterval)period;
+
+/** Initializes and returns a newly allocated cache object with the supplied memory cache, other tile caches and expiry period.
+ *
+ *   @param memoryCache RMMemoryCache object to be used for fast memory-based caching of the most recently used tiles.
+ *   @param caches An array containing memory-based or disk-based caches implementing the `RMTileCache` protocol.
+ *   @param period A period of time after which tiles should be expunged from the cache.
+ *   @return An initialized cache object or `nil` if the object couldn't be created. */
+- (id)initWithMemoryCache:(RMMemoryCache *)memoryCache otherCaches:(NSArray *)caches andExpiryPeriod:(NSTimeInterval)period;
 
 /** @name Identifying Cache Objects */
 
@@ -105,8 +132,13 @@ typedef enum : short {
 - (void)addCache:(id <RMTileCache>)cache;
 - (void)insertCache:(id <RMTileCache>)cache atIndex:(NSUInteger)index;
 
-/** The list of caches managed by a cache manager. This could include memory-based, disk-based, or other types of caches. */
-@property (nonatomic, readonly, strong) NSArray *tileCaches;
+/** Removes a given cache from the cache management system.
+ *
+ *   @param cache A memory-based or disk-based cache. */
+- (void)removeCache:(id <RMTileCache>)cache;
+
+/** The list of caches managed by a cache manager. This could include memory-based, disk-based, or other types of caches conforming to the RMTileCache protocol. */
+@property (nonatomic, strong) NSArray *tileCaches;
 
 - (void)didReceiveMemoryWarning;
 

--- a/MapView/Map/RMTileCache.h
+++ b/MapView/Map/RMTileCache.h
@@ -76,8 +76,6 @@ typedef enum : short {
 *
 *   An RMMapView has one RMTileCache across all tile sources, which is further divided according to each tile source's uniqueTilecacheKey property in order to keep tiles separate in the cache.
 *
-*   An RMTileCache is a key component of offline map use. All tile requests pass through the tile cache and are served from cache if available, avoiding network operation. If tiles exist in cache already, a tile source that is instantiated when offline will still be able to serve tile imagery to the map renderer for areas that have been previously cached. This can occur either from normal map use, since all tiles are cached after being retrieved, or from proactive caching ahead of time using the beginBackgroundCacheForTileSource:southWest:northEast:minZoom:maxZoom: method. 
-*
 *   @see [RMDatabaseCache initUsingCacheDir:] */
 @interface RMTileCache : NSObject <RMTileCache>
 

--- a/MapView/Map/RMTileCache.h
+++ b/MapView/Map/RMTileCache.h
@@ -72,36 +72,6 @@ typedef enum : short {
 
 #pragma mark -
 
-/** The RMTileCacheBackgroundDelegate protocol is for receiving notifications about background tile cache download operations. */
-@protocol RMTileCacheBackgroundDelegate <NSObject>
-
-@optional
-
-/** Sent when the background caching operation begins.
-*   @param tileCache The tile cache. 
-*   @param tileCount The total number of tiles required for coverage of the desired geographic area. 
-*   @param tileSource The tile source providing the tiles. */
-- (void)tileCache:(RMTileCache *)tileCache didBeginBackgroundCacheWithCount:(int)tileCount forTileSource:(id <RMTileSource>)tileSource;
-
-/** Sent upon caching of each tile in a background cache operation.
-*   @param tileCache The tile cache. 
-*   @param tile A structure representing the tile in question. 
-*   @param tileIndex The index of the tile in question, beginning with `1` and ending with totalTileCount. 
-*   @param totalTileCount The total number of of tiles required for coverage of the desired geographic area. */
-- (void)tileCache:(RMTileCache *)tileCache didBackgroundCacheTile:(RMTile)tile withIndex:(int)tileIndex ofTotalTileCount:(int)totalTileCount;
-
-/** Sent when all tiles have completed downloading and caching. 
-*   @param tileCache The tile cache. */
-- (void)tileCacheDidFinishBackgroundCache:(RMTileCache *)tileCache;
-
-/** Sent when the cache download operation has completed cancellation and the cache object is safe to dispose of. 
-*   @param tileCache The tile cache. */
-- (void)tileCacheDidCancelBackgroundCache:(RMTileCache *)tileCache;
-
-@end
-
-#pragma mark -
-
 /** An RMTileCache object manages memory-based and disk-based caches for map tiles that have been retrieved from the network. 
 *
 *   An RMMapView has one RMTileCache across all tile sources, which is further divided according to each tile source's uniqueTilecacheKey property in order to keep tiles separate in the cache.
@@ -141,26 +111,5 @@ typedef enum : short {
 @property (nonatomic, readonly, strong) NSArray *tileCaches;
 
 - (void)didReceiveMemoryWarning;
-
-/** @name Background Downloading */
-
-/** A delegate to notify of background tile cache download operations. */
-@property (nonatomic, weak) id <RMTileCacheBackgroundDelegate>backgroundCacheDelegate;
-
-/** Whether or not the tile cache is currently background caching. */
-@property (nonatomic, readonly, assign) BOOL isBackgroundCaching;
-
-/** Tells the tile cache to begin background caching. Progress during the caching operation can be observed by implementing the RMTileCacheBackgroundDelegate protocol.
-*   @param tileSource The tile source from which to retrieve tiles.
-*   @param southWest The southwest corner of the geographic area to cache.
-*   @param northEast The northeast corner of the geographic area to cache. 
-*   @param minZoom The minimum zoom level to cache. 
-*   @param maxZoom The maximum zoom level to cache. */
-- (void)beginBackgroundCacheForTileSource:(id <RMTileSource>)tileSource southWest:(CLLocationCoordinate2D)southWest northEast:(CLLocationCoordinate2D)northEast minZoom:(float)minZoom maxZoom:(float)maxZoom;
-
-/** Cancel any background caching. 
-*
-*   This method returns immediately so as to not block the calling thread. If you wish to be notified of the actual cancellation completion, implement the tileCacheDidCancelBackgroundCache: delegate method. */
-- (void)cancelBackgroundCache;
 
 @end

--- a/MapView/Map/RMTileCache.m
+++ b/MapView/Map/RMTileCache.m
@@ -34,8 +34,6 @@
 #import "RMConfiguration.h"
 #import "RMTileSource.h"
 
-#import "RMTileCacheDownloadOperation.h"
-
 @interface RMTileCache (Configuration)
 
 - (id <RMTileCache>)memoryCacheWithConfig:(NSDictionary *)cfg;
@@ -54,12 +52,7 @@
     NSTimeInterval _expiryPeriod;
 
     dispatch_queue_t _tileCacheQueue;
-    
-    id <RMTileSource>_activeTileSource;
-    NSOperationQueue *_backgroundFetchQueue;
 }
-
-@synthesize backgroundCacheDelegate=_backgroundCacheDelegate;
 
 - (id)initWithExpiryPeriod:(NSTimeInterval)period
 {
@@ -72,10 +65,6 @@
     _memoryCache = nil;
     _expiryPeriod = period;
     
-    _backgroundCacheDelegate = nil;
-    _activeTileSource = nil;
-    _backgroundFetchQueue = nil;
-
     id cacheCfg = [[RMConfiguration configuration] cacheConfiguration];
     if (!cacheCfg)
         cacheCfg = [NSArray arrayWithObjects:
@@ -124,9 +113,6 @@
 
 - (void)dealloc
 {
-    if (self.isBackgroundCaching)
-        [self cancelBackgroundCache];
-    
     dispatch_barrier_sync(_tileCacheQueue, ^{
          _memoryCache = nil;
          _tileCaches = nil;
@@ -243,129 +229,6 @@
         for (id<RMTileCache> cache in _tileCaches)
         {
             [cache removeAllCachedImagesForCacheKey:cacheKey];
-        }
-    });
-}
-
-- (BOOL)isBackgroundCaching
-{
-    return (_activeTileSource || _backgroundFetchQueue);
-}
-
-- (void)beginBackgroundCacheForTileSource:(id <RMTileSource>)tileSource southWest:(CLLocationCoordinate2D)southWest northEast:(CLLocationCoordinate2D)northEast minZoom:(float)minZoom maxZoom:(float)maxZoom
-{
-    if (self.isBackgroundCaching)
-        return;
-
-    _activeTileSource = tileSource;
-    
-    _backgroundFetchQueue = [[NSOperationQueue alloc] init];
-    [_backgroundFetchQueue setMaxConcurrentOperationCount:6];
-    
-    int   minCacheZoom = (int)minZoom;
-    int   maxCacheZoom = (int)maxZoom;
-    float minCacheLat  = southWest.latitude;
-    float maxCacheLat  = northEast.latitude;
-    float minCacheLon  = southWest.longitude;
-    float maxCacheLon  = northEast.longitude;
-
-    if (maxCacheZoom < minCacheZoom || maxCacheLat <= minCacheLat || maxCacheLon <= minCacheLon)
-        return;
-
-    int n, xMin, yMax, xMax, yMin;
-
-    int totalTiles = 0;
-
-    for (int zoom = minCacheZoom; zoom <= maxCacheZoom; zoom++)
-    {
-        n = pow(2.0, zoom);
-        xMin = floor(((minCacheLon + 180.0) / 360.0) * n);
-        yMax = floor((1.0 - (logf(tanf(minCacheLat * M_PI / 180.0) + 1.0 / cosf(minCacheLat * M_PI / 180.0)) / M_PI)) / 2.0 * n);
-        xMax = floor(((maxCacheLon + 180.0) / 360.0) * n);
-        yMin = floor((1.0 - (logf(tanf(maxCacheLat * M_PI / 180.0) + 1.0 / cosf(maxCacheLat * M_PI / 180.0)) / M_PI)) / 2.0 * n);
-
-        totalTiles += (xMax + 1 - xMin) * (yMax + 1 - yMin);
-    }
-
-    [_backgroundCacheDelegate tileCache:self didBeginBackgroundCacheWithCount:totalTiles forTileSource:_activeTileSource];
-
-    __block int progTile = 0;
-
-    for (int zoom = minCacheZoom; zoom <= maxCacheZoom; zoom++)
-    {
-        n = pow(2.0, zoom);
-        xMin = floor(((minCacheLon + 180.0) / 360.0) * n);
-        yMax = floor((1.0 - (logf(tanf(minCacheLat * M_PI / 180.0) + 1.0 / cosf(minCacheLat * M_PI / 180.0)) / M_PI)) / 2.0 * n);
-        xMax = floor(((maxCacheLon + 180.0) / 360.0) * n);
-        yMin = floor((1.0 - (logf(tanf(maxCacheLat * M_PI / 180.0) + 1.0 / cosf(maxCacheLat * M_PI / 180.0)) / M_PI)) / 2.0 * n);
-
-        for (int x = xMin; x <= xMax; x++)
-        {
-            for (int y = yMin; y <= yMax; y++)
-            {
-                RMTileCacheDownloadOperation *operation = [[RMTileCacheDownloadOperation alloc] initWithTile:RMTileMake(x, y, zoom)
-                                                                                                forTileSource:_activeTileSource
-                                                                                                   usingCache:self];
-
-                __block RMTileCacheDownloadOperation *internalOperation = operation;
-
-                [operation setCompletionBlock:^(void)
-                {
-                    dispatch_sync(dispatch_get_main_queue(), ^(void)
-                    {
-                        if ( ! [internalOperation isCancelled])
-                        {
-                            progTile++;
-
-                            [_backgroundCacheDelegate tileCache:self didBackgroundCacheTile:RMTileMake(x, y, zoom) withIndex:progTile ofTotalTileCount:totalTiles];
-
-                            if (progTile == totalTiles)
-                            {
-                                 _backgroundFetchQueue = nil;
-
-                                 _activeTileSource = nil;
-
-                                [_backgroundCacheDelegate tileCacheDidFinishBackgroundCache:self];
-                            }
-                        }
-
-                        internalOperation = nil;
-                    });
-                }];
-
-                [_backgroundFetchQueue addOperation:operation];
-            }
-        }
-    };
-}
-
-- (void)cancelBackgroundCache
-{
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^(void)
-    {
-        @synchronized (self)
-        {
-            BOOL didCancel = NO;
-
-            if (_backgroundFetchQueue)
-            {
-                [_backgroundFetchQueue cancelAllOperations];
-                [_backgroundFetchQueue waitUntilAllOperationsAreFinished];
-                 _backgroundFetchQueue = nil;
-
-                didCancel = YES;
-            }
-
-            if (_activeTileSource)
-                 _activeTileSource = nil;
-
-            if (didCancel)
-            {
-                dispatch_sync(dispatch_get_main_queue(), ^(void)
-                {
-                    [_backgroundCacheDelegate tileCacheDidCancelBackgroundCache:self];
-                });
-            }
         }
     });
 }

--- a/MapView/MapView.xcodeproj/project.pbxproj
+++ b/MapView/MapView.xcodeproj/project.pbxproj
@@ -105,8 +105,8 @@
 		DD3BEF7A15913C55007892D8 /* RMAttributionViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = DD3BEF7815913C55007892D8 /* RMAttributionViewController.m */; };
 		DD4195C9162356900049E6BA /* RMBingSource.h in Headers */ = {isa = PBXBuildFile; fileRef = DD4195C7162356900049E6BA /* RMBingSource.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD4195CA162356900049E6BA /* RMBingSource.m in Sources */ = {isa = PBXBuildFile; fileRef = DD4195C8162356900049E6BA /* RMBingSource.m */; };
-		DD41960116250ED40049E6BA /* RMTileCacheDownloadOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = DD4195FF16250ED40049E6BA /* RMTileCacheDownloadOperation.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		DD41960216250ED40049E6BA /* RMTileCacheDownloadOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = DD41960016250ED40049E6BA /* RMTileCacheDownloadOperation.m */; };
+		DD41960116250ED40049E6BA /* RMDatabaseCacheDownloadOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = DD4195FF16250ED40049E6BA /* RMDatabaseCacheDownloadOperation.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		DD41960216250ED40049E6BA /* RMDatabaseCacheDownloadOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = DD41960016250ED40049E6BA /* RMDatabaseCacheDownloadOperation.m */; };
 		DD41961F16263E400049E6BA /* libGRMustache5-iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DD41961E16263E400049E6BA /* libGRMustache5-iOS.a */; };
 		DD4BE198161CE296003EF677 /* MapBox.h in Headers */ = {isa = PBXBuildFile; fileRef = DD4BE197161CE296003EF677 /* MapBox.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DD5A200B15CAD09400FE4157 /* GRMustache.h in Headers */ = {isa = PBXBuildFile; fileRef = DD5A200A15CAD09400FE4157 /* GRMustache.h */; };
@@ -265,8 +265,8 @@
 		DD3BEF7815913C55007892D8 /* RMAttributionViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RMAttributionViewController.m; sourceTree = "<group>"; };
 		DD4195C7162356900049E6BA /* RMBingSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RMBingSource.h; sourceTree = "<group>"; };
 		DD4195C8162356900049E6BA /* RMBingSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RMBingSource.m; sourceTree = "<group>"; };
-		DD4195FF16250ED40049E6BA /* RMTileCacheDownloadOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RMTileCacheDownloadOperation.h; sourceTree = "<group>"; };
-		DD41960016250ED40049E6BA /* RMTileCacheDownloadOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RMTileCacheDownloadOperation.m; sourceTree = "<group>"; };
+		DD4195FF16250ED40049E6BA /* RMDatabaseCacheDownloadOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RMDatabaseCacheDownloadOperation.h; sourceTree = "<group>"; };
+		DD41960016250ED40049E6BA /* RMDatabaseCacheDownloadOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RMDatabaseCacheDownloadOperation.m; sourceTree = "<group>"; };
 		DD41961E16263E400049E6BA /* libGRMustache5-iOS.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libGRMustache5-iOS.a"; path = "GRMustache/lib/libGRMustache5-iOS.a"; sourceTree = "<group>"; };
 		DD4BE197161CE296003EF677 /* MapBox.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MapBox.h; sourceTree = "<group>"; };
 		DD5A200A15CAD09400FE4157 /* GRMustache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GRMustache.h; path = GRMustache/include/GRMustache.h; sourceTree = "<group>"; };
@@ -435,8 +435,8 @@
 				16EC85D1133CA6C300219947 /* RMCacheObject.m */,
 				B83E64D00E80E73F001663B6 /* RMTileCache.h */,
 				B83E64D10E80E73F001663B6 /* RMTileCache.m */,
-				DD4195FF16250ED40049E6BA /* RMTileCacheDownloadOperation.h */,
-				DD41960016250ED40049E6BA /* RMTileCacheDownloadOperation.m */,
+				DD4195FF16250ED40049E6BA /* RMDatabaseCacheDownloadOperation.h */,
+				DD41960016250ED40049E6BA /* RMDatabaseCacheDownloadOperation.m */,
 				B83E64D20E80E73F001663B6 /* RMMemoryCache.h */,
 				B83E64D30E80E73F001663B6 /* RMMemoryCache.m */,
 				B8474B980EB40094006A0BC1 /* RMDatabaseCache.h */,
@@ -719,7 +719,7 @@
 				161E563A1594664E00B00BB6 /* RMOpenSeaMapLayer.h in Headers */,
 				1656665515A1DF7900EF3DC7 /* RMCoordinateGridSource.h in Headers */,
 				DD5FA1EB15E2B020004EB6C5 /* RMLoadingTileView.h in Headers */,
-				DD41960116250ED40049E6BA /* RMTileCacheDownloadOperation.h in Headers */,
+				DD41960116250ED40049E6BA /* RMDatabaseCacheDownloadOperation.h in Headers */,
 				DD4195C9162356900049E6BA /* RMBingSource.h in Headers */,
 				DD2B374514CF8041008DE8CB /* FMDatabase.h in Headers */,
 				DD2B374714CF8041008DE8CB /* FMDatabaseAdditions.h in Headers */,
@@ -878,7 +878,7 @@
 				1656665615A1DF7900EF3DC7 /* RMCoordinateGridSource.m in Sources */,
 				16E5A63B15E531F200C92A5A /* RMCompositeSource.m in Sources */,
 				DD5FA1EC15E2B020004EB6C5 /* RMLoadingTileView.m in Sources */,
-				DD41960216250ED40049E6BA /* RMTileCacheDownloadOperation.m in Sources */,
+				DD41960216250ED40049E6BA /* RMDatabaseCacheDownloadOperation.m in Sources */,
 				DD4195CA162356900049E6BA /* RMBingSource.m in Sources */,
 				DD1E3C6F161F954F004FC649 /* SMCalloutView.m in Sources */,
 				DD7C7E39164C894F0021CCA5 /* RMStaticMapView.m in Sources */,


### PR DESCRIPTION
This pull request fixes issues https://github.com/mapbox/mapbox-ios-sdk/issues/281 and https://github.com/mapbox/mapbox-ios-sdk/issues/284.

The move of background caching to `RMDatabaseCache` was pretty straightforward. But this is still quite a significant change, so I'll be happy to discuss if there are any questions. Below is an overview of the changes.

**nil passed to inCache parameter when requesting image from tile source**
Since we are no longer performing this as part of `RMTileCache`, it will not be available to look for pre-existing cached images. As a result, in `RMDatabaseCacheDownloadOperation`, images are requested from the tile source by:
`UIImage *image = [_source imageForTile:_tile inCache:nil];`
Passing `nil` to the `inCache` parameter has two effects:
1. We will not use an `RMTileCache` to look for images first, they are always downloaded fresh. This could waste some bandwidth if the tiles have been previously downloaded into another cache, but I think the cleaner design is worth the tradeoff.
2. Passing `nil` to this parameter results in `nil` being messaged (when the tile source attempts to retrieve the images from the cache). This isn't a problem in itself, but we should make sure that tile sources can handle this.

**Fix for exceeding kWriteQueueLimit**
Before the changes in this commit, I noticed that background caching was frequently causing the `kWriteQueueLimit` to be exceeded, meaning the tile image would get downloaded, but not written to the database. This was often quite severe, sometimes resulting in more than 80% of images to be discarded. Because background download operations already live on their own `NSOperationQueue`, there is no need to again perform the tile saving on a separate queue. So I added another method:
`- (void)addImageAndWait:(UIImage *)image forTile:(RMTile)tile withCacheKey:(NSString *)aCacheKey`
This is used by the download operations to save the image to the cache, fixing the problem of skipped tiles.

**Gracefully skip existing tiles**
A boolean property, `tileExisted`, was added to `RMDatabaseCacheDownloadOperation` to indicate whether the tile was already in the cache. This is used to better support resuming of download operations, the delegate will only be notified of new tiles which have been downloaded. It is also using the new `containsTile:withCacheKey:` method which should provide lower overhead than `cachedImage:withCacheKey:`.

**Additional changes**
- Added `withIdentifier:(id)identifier` parameter to various background caching methods, an arbitrary object which will be provided back to the delegate to identify the download operation.
- Added `readOnly`, `imageType` and `jpegQuality` properties to `RMDatabaseCache`.
