### PR TITLE
beginBackgroundCacheForTileSource : Move initializations after initial checks

### DIFF
--- a/MapView/Map/RMTileCache.m
+++ b/MapView/Map/RMTileCache.m
@@ -256,11 +256,6 @@
 {
     if (self.isBackgroundCaching)
         return;
-
-    _activeTileSource = tileSource;
-    
-    _backgroundFetchQueue = [[NSOperationQueue alloc] init];
-    [_backgroundFetchQueue setMaxConcurrentOperationCount:6];
     
     int   minCacheZoom = (int)minZoom;
     int   maxCacheZoom = (int)maxZoom;
@@ -271,6 +266,11 @@
 
     if (maxCacheZoom < minCacheZoom || maxCacheLat <= minCacheLat || maxCacheLon <= minCacheLon)
         return;
+    
+    _activeTileSource = tileSource;
+    
+    _backgroundFetchQueue = [[NSOperationQueue alloc] init];
+    [_backgroundFetchQueue setMaxConcurrentOperationCount:6];
 
     int n, xMin, yMax, xMax, yMin;
 


### PR DESCRIPTION
Move initializations after initial checks to avoid initializing when the values (Zoom, coordinates, ...) are not correct.

This fix an issue where isBackgroundCaching always returns true even if the background caching is not running.

isBackgroundCaching checks for _activeTileSource || _backgroundFetchQueue. If the Zoom or coordinates is not correct the method will return and the background caching will not start. isBackgroundCaching will then always return true and prevent the code to try to start the background caching again. By moving the initialization after the check, if the method is called again with correct values, the background caching will be able to start normally.
