### PR TITLE
Add custom content view ability to MapBox marker (Integrate SMCalloutView custom contentView to MapBox)

### DIFF
--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -1747,6 +1747,12 @@
         {
             _currentCallout = [SMCalloutView new];
 
+            // If a custom contentView was assigned to the marker then we would assigned that to contentView of _currentCallout.
+            // By this assignment title/subtitle/titleView/subtitleView are all ignored and custom content view will be used. 
+            if ([anAnnotation.layer isKindOfClass:[RMMarker class]] && ((RMMarker *)anAnnotation.layer).contentView) {
+                _currentCallout.contentView = ((RMMarker *)anAnnotation.layer).contentView;
+            }
+            
             _currentCallout.backgroundView = [SMCalloutBackgroundView systemBackgroundView];
 
             _currentCallout.title    = anAnnotation.title;

--- a/MapView/Map/RMMarker.h
+++ b/MapView/Map/RMMarker.h
@@ -46,6 +46,10 @@ typedef enum {
     UIColor *textBackgroundColor;
 }
 
+/** @name Custom "content" view */
+/** Custom "content" view that can be any width/height. If this is set, title/subtitle/titleView/subtitleView are all ignored. */
+@property (nonatomic, retain) UIView *contentView;
+
 /** @name Setting Label Properties */
 
 /** A custom label for the marker. The label is shown when first set. */

--- a/MapView/Map/RMMarker.m
+++ b/MapView/Map/RMMarker.m
@@ -35,6 +35,7 @@
 @synthesize label;
 @synthesize textForegroundColor;
 @synthesize textBackgroundColor;
+@synthesize contentView;
 
 #define defaultMarkerAnchorPoint CGPointMake(0.5, 0.5)
 


### PR DESCRIPTION
@incanus

I wanted to use custom view for RMMarker to use larger image and multiline description for my annotations.

I saw that SMCalloutView supports this feature with "custom content view".
If we could set contentView property of SMCalloutView, it would ignore title/subtile/... and instead it would use our custom view.
So I added a property to RMMarker as "contentView" and in RMMapView class I checked that if contentView property of our marker was assigned, it would assign that to contentView property of current SMCalloutView (line 1753).
By this change we just need to create our custom UIView and assign it to our marker by writing a code like this: myMarker.contentView = myCustomUIView;

It's obvious that we can add many objects to our UIView such as label, image, textView, ...
Fortunately, SMCalloutView supports touch in this custom content view so for example we can scroll textView that we add to our custom content view.

The image below shows the result of these changes:
(As you can see there are label, image with shadow and a textView with vertical scrollBar for cafe address and phone in my custom content view)

![markercustomview](https://f.cloud.github.com/assets/4446420/1213070/fa478bdc-2622-11e3-99af-8b29bb90c9a5.jpg)

One more thing must be done to achieve this result properly. We must use at least Mar 20, 2013 revision of SMCalloutView which is this version:
https://github.com/nfarina/calloutview/blob/0fd8fdb339b5db8ba9c984935a2e0d474cf48824/SMCalloutView.m

I use this solution in one of my apps which have had about 1000 users for two weeks of its release date and I haven't received any crash or bug report related to this feature.

Best Regards,
Nima Azimi
