### PR TITLE
Bugfix: RMMapTiledLayerView

### DIFF
--- a/MapView/Map/RMMapTiledLayerView.m
+++ b/MapView/Map/RMMapTiledLayerView.m
@@ -176,7 +176,7 @@
                     {
                         // ensure only one request for a URL at a time
                         //
-                        @synchronized ([(RMAbstractWebMapSource *)_tileSource URLForTile:RMTileMake(x, y, zoom)])
+                        @synchronized ([(RMAbstractWebMapSource *)_tileSource URLsForTile:RMTileMake(x, y, zoom)])
                         {
                             // this will return quicker if cached since above attempt, else block on fetch
                             //


### PR DESCRIPTION
Bugfix: fixes muti-layered tile sources (such as OpenSeaMap): call `URLsForTile` instead of `URLForTile` in `RMMapTiledLayerView`. This should fix issues https://github.com/mapbox/mapbox-ios-sdk/issues/163 and https://github.com/mapbox/mapbox-ios-sdk/issues/175.
