### PR TITLE
Bugfix: userLocation marker image is not replacing marker image on map while map is rotating

### DIFF
--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -427,6 +427,7 @@
     [_zoomDelegateQueue cancelAllOperations];
     [[NSNotificationCenter defaultCenter] removeObserver:self];
     [_mapScrollView removeObserver:self forKeyPath:@"contentOffset"];
+    [_userLocation.layer removeObserver:self forKeyPath:@"contents"];
     [_tileSourcesContainer cancelAllDownloads];
     _locationManager.delegate = nil;
     [_locationManager stopUpdatingLocation];
@@ -1400,6 +1401,15 @@
 
 - (void)observeValueForKeyPath:(NSString *)aKeyPath ofObject:(id)anObject change:(NSDictionary *)change context:(void *)context
 {
+    if (anObject == _userLocation.layer) {
+        if (_userLocationTrackingView) {
+            _userLocationTrackingView.image = [UIImage imageWithCGImage:(CGImageRef)_userLocation.layer.contents
+                                                                  scale:_userLocation.layer.contentsScale
+                                                            orientation:UIImageOrientationUp];
+        }
+        return;
+    }
+    
     NSValue *oldValue = [change objectForKey:NSKeyValueChangeOldKey],
             *newValue = [change objectForKey:NSKeyValueChangeNewKey];
 
@@ -3109,7 +3119,7 @@
 
             if (_userLocationTrackingView || _userHeadingTrackingView || _userHaloTrackingView)
             {
-                [_userLocationTrackingView removeFromSuperview]; _userLocationTrackingView = nil;
+                [_userLocationTrackingView removeFromSuperview]; _userLocationTrackingView = nil; [_userLocation.layer removeObserver:self forKeyPath:@"contents"];
                 [_userHeadingTrackingView removeFromSuperview]; _userHeadingTrackingView = nil;
                 [_userHaloTrackingView removeFromSuperview]; _userHaloTrackingView = nil;
             }
@@ -3132,7 +3142,7 @@
 
             if (_userLocationTrackingView || _userHeadingTrackingView || _userHaloTrackingView)
             {
-                [_userLocationTrackingView removeFromSuperview]; _userLocationTrackingView = nil;
+                [_userLocationTrackingView removeFromSuperview]; _userLocationTrackingView = nil; [_userLocation.layer removeObserver:self forKeyPath:@"contents"];
                 [_userHeadingTrackingView removeFromSuperview]; _userHeadingTrackingView = nil;
                 [_userHaloTrackingView removeFromSuperview]; _userHaloTrackingView = nil;
             }
@@ -3212,6 +3222,8 @@
                                                          UIViewAutoresizingFlexibleBottomMargin;
             
             [self insertSubview:_userLocationTrackingView aboveSubview:_userHeadingTrackingView];
+            
+            [_userLocation.layer addObserver:self forKeyPath:@"contents" options:NSKeyValueObservingOptionNew context:NULL];
 
             if (self.zoom < 3)
                 [self zoomByFactor:exp2f(3 - [self zoom]) near:self.center animated:YES];

--- a/MapView/Map/RMMarker.m
+++ b/MapView/Map/RMMarker.m
@@ -170,11 +170,13 @@
 
 - (void)replaceUIImage:(UIImage *)image anchorPoint:(CGPoint)_anchorPoint
 {
+    [self willChangeValueForKey:@"contents"];
     self.contents = (id)[image CGImage];
     self.bounds = CGRectMake(0, 0, image.size.width, image.size.height);
     self.anchorPoint = _anchorPoint;
 
     self.masksToBounds = NO;
+    [self didChangeValueForKey:@"contents"];
 }
 
 - (void)setLabel:(UIView *)aView


### PR DESCRIPTION
When the userLocation marker image is changed while the map is rotating, the marker image on the map is not replaced. This is caused by hiding the userLocation annotation and showing an UIImageView instead. 

To fix this behavior i've added an observer to the content of the userLocation.layer. When it is changed, the image of the shown image view is also changed.
