### PR TITLE
disable repositioning of the map when a callout is displayed, in case userTrackingMode is active

### DIFF
--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -1819,6 +1819,12 @@
 
 - (NSTimeInterval)calloutView:(SMCalloutView *)calloutView delayForRepositionWithSize:(CGSize)offset
 {
+    if (self.userTrackingMode != RMUserTrackingModeNone)
+    {
+        // prevent buggy repositioning of the user location
+        return 0.0;
+    }
+    
     [self registerMoveEventByUser:NO];
 
     CGPoint contentOffset = _mapScrollView.contentOffset;


### PR DESCRIPTION
I closed the previous pull request #307 as it contained additional commits that didn’t belong to the pull requrest.

When callouts for annotations are displayed, MapBox might reposition the map to center the view on the callout. However when the userTrackingMode is set, this results in a buggy placement of the position marker. It doesn't make much sense to center the view on the callout when the tracking is active, because it will move back to the users position almost instantly.
