### PR TITLE
Fix podspec warnings

### DIFF
--- a/MapBox.podspec
+++ b/MapBox.podspec
@@ -21,52 +21,7 @@ Pod::Spec.new do |m|
 
   m.prefix_header_file = 'MapView/MapView_Prefix.pch'
 
-  m.pre_install do |pod, target_definition|
-    Dir.chdir(pod.root) do
-      command = "xcodebuild -project MapView/MapView.xcodeproj -target Resources CONFIGURATION_BUILD_DIR=../Resources 2>&1 > /dev/null"
-      unless system(command)
-        raise ::Pod::Informative, "Failed to generate MapBox resources bundle"
-      end
-    end
-  end
-
-  m.resource = 'Resources/MapBox.bundle'
-
-  m.documentation = {
-    :html => 'http://mapbox.com/mapbox-ios-sdk/api/',
-    :appledoc => [
-      '--project-company', 'MapBox',
-      '--docset-copyright', 'MapBox',
-      '--no-keep-undocumented-objects',
-      '--no-keep-undocumented-members',
-      '--ignore', '.c',
-      '--ignore', '.m',
-      '--ignore', 'Proj4',
-      '--ignore', 'RMAttributionViewController.h',
-      '--ignore', 'RMBingSource.h',
-      '--ignore', 'RMCoordinateGridSource.h',
-      '--ignore', 'RMDBMapSource.h',
-      '--ignore', 'RMFoundation.h',
-      '--ignore', 'RMFractalTileProjection.h',
-      '--ignore', 'RMGenericMapSource.h',
-      '--ignore', 'RMGlobalConstants.h',
-      '--ignore', 'RMLoadingTileView.h',
-      '--ignore', 'RMMapOverlayView.h',
-      '--ignore', 'RMMapQuestOpenAerialSource.h',
-      '--ignore', 'RMMapQuestOSMSource.h',
-      '--ignore', 'RMMapScrollView.h',
-      '--ignore', 'RMMapTiledLayerView.h',
-      '--ignore', 'RMNotifications.h',
-      '--ignore', 'RMOpenCycleMapSource.h',
-      '--ignore', 'RMOpenSeaMapLayer.h',
-      '--ignore', 'RMOpenSeaMapSource.h',
-      '--ignore', 'RMPixel.h',
-      '--ignore', 'RMProjection.h',
-      '--ignore', 'RMTile.h',
-      '--ignore', 'RMTileImage.h',
-      '--ignore', 'RMTileSourcesContainer.h',
-    ]
-  }
+  m.resource_bundles = { 'MapBox' => ['MapView/Map/Resources/*'] }
 
   m.documentation_url = 'https://www.mapbox.com/mapbox-ios-sdk/api/'
 
@@ -78,7 +33,7 @@ Pod::Spec.new do |m|
 
   m.preserve_paths = 'Proj4/libProj4.a', 'MapView/MapView.xcodeproj', 'MapView/Map/Resources'
 
-  m.dependency 'FMDB', '2.0'
+  m.dependency 'FMDB', '2.1'
   m.dependency 'GRMustache', '5.4.3'
   m.dependency 'SMCalloutView', '1.1'
 


### PR DESCRIPTION
- Use new `resource_bundles` directive
- Remove deprecated `documentation` directive
- Upgrade FMDB to version 2.1 to fix its warnings
