### PR TITLE
Fix crash with hidden logo bug

### DIFF
--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -533,7 +533,7 @@
         }
     }
 
-    if (_logoBug)
+    if (_logoBug && _showLogoBug)
     {
         if ( ! [[viewController.view valueForKeyPath:@"constraints.firstItem"]  containsObject:_logoBug] &&
              ! [[viewController.view valueForKeyPath:@"constraints.secondItem"] containsObject:_logoBug])


### PR DESCRIPTION
Autolayout freaks out if it tries to layout a hidden logo bug. This is easily fixed by checking the logo bug is not nil and should be shown
