### PR TITLE
Added call to [super updateConstraints] when no view controller could be found

### DIFF
--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -500,7 +500,10 @@
     // just stick with the initial frames.
     //
     if ( ! viewController)
+    {
+        [super updateConstraints];
         return;
+    }
 
     // compass
     //


### PR DESCRIPTION
The early return from the updateConstraints override when the map view isn't contained in a view controller (e.g. if it's embedded in a UIWindow) meant that the super class implementation wasn't being called (as per Apple's documentation: https://developer.apple.com/library/ios/documentation/uikit/reference/uiview_class/UIView/UIView.html#jumpTo_121), causing a crash.
