### PR TITLE
Background rendering fix

### DIFF
--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -360,7 +360,7 @@
 
 - (id)initWithFrame:(CGRect)frame andTilesource:(id <RMTileSource>)newTilesource
 {
-    return [self initWithFrame:frame
+	return [self initWithFrame:frame
                  andTilesource:newTilesource
               centerCoordinate:CLLocationCoordinate2DMake(kDefaultInitialLatitude, kDefaultInitialLongitude)
                      zoomLevel:kDefaultInitialZoomLevel
@@ -456,7 +456,7 @@
 
 - (void)handleMemoryWarningNotification:(NSNotification *)notification
 {
-    [self didReceiveMemoryWarning];
+	[self didReceiveMemoryWarning];
 }
 
 - (void)handleWillChangeOrientationNotification:(NSNotification *)notification
@@ -644,9 +644,9 @@
 
 - (NSString *)description
 {
-    CGRect bounds = self.bounds;
+	CGRect bounds = self.bounds;
 
-    return [NSString stringWithFormat:@"MapView at {%.0f,%.0f}-{%.0fx%.0f}", bounds.origin.x, bounds.origin.y, bounds.size.width, bounds.size.height];
+	return [NSString stringWithFormat:@"MapView at {%.0f,%.0f}-{%.0fx%.0f}", bounds.origin.x, bounds.origin.y, bounds.size.width, bounds.size.height];
 }
 
 #pragma mark -
@@ -654,7 +654,7 @@
 
 - (id <RMMapViewDelegate>)delegate
 {
-    return _delegate;
+	return _delegate;
 }
 
 - (void)setDelegate:(id <RMMapViewDelegate>)aDelegate
@@ -974,9 +974,9 @@
 //    RMLog(@"Current contentSize: {%.0f,%.0f}, zoom: %f", mapScrollView.contentSize.width, mapScrollView.contentSize.height, self.zoom);
 
     RMProjectedRect planetBounds = _projection.planetBounds;
-    RMProjectedPoint normalizedProjectedPoint;
-    normalizedProjectedPoint.x = centerProjectedPoint.x + fabs(planetBounds.origin.x);
-    normalizedProjectedPoint.y = centerProjectedPoint.y + fabs(planetBounds.origin.y);
+	RMProjectedPoint normalizedProjectedPoint;
+	normalizedProjectedPoint.x = centerProjectedPoint.x + fabs(planetBounds.origin.x);
+	normalizedProjectedPoint.y = centerProjectedPoint.y + fabs(planetBounds.origin.y);
 
     [_mapScrollView setContentOffset:CGPointMake(normalizedProjectedPoint.x / _metersPerPixel - _mapScrollView.bounds.size.width/2.0,
                                                 _mapScrollView.contentSize.height - ((normalizedProjectedPoint.y / _metersPerPixel) + _mapScrollView.bounds.size.height/2.0))
@@ -1032,9 +1032,9 @@
         boundsRect = [self fitProjectedRect:boundsRect intoRect:_constrainingProjectedBounds];
 
     RMProjectedRect planetBounds = _projection.planetBounds;
-    RMProjectedPoint normalizedProjectedPoint;
-    normalizedProjectedPoint.x = boundsRect.origin.x + fabs(planetBounds.origin.x);
-    normalizedProjectedPoint.y = boundsRect.origin.y + fabs(planetBounds.origin.y);
+	RMProjectedPoint normalizedProjectedPoint;
+	normalizedProjectedPoint.x = boundsRect.origin.x + fabs(planetBounds.origin.x);
+	normalizedProjectedPoint.y = boundsRect.origin.y + fabs(planetBounds.origin.y);
 
     float zoomScale = _mapScrollView.zoomScale;
     CGRect zoomRect = CGRectMake((normalizedProjectedPoint.x / _metersPerPixel) / zoomScale,
@@ -1067,24 +1067,17 @@
 
 - (void)setZoom:(float)newZoom atCoordinate:(CLLocationCoordinate2D)newCenter animated:(BOOL)animated
 {
-    if (animated) {
-        [UIView animateWithDuration:(0.3)
-                              delay:0.0
-                            options:UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationCurveEaseInOut
-                         animations:^(void)
-                         {
-                             [self setZoom:newZoom];
-                             [self setCenterCoordinate:newCenter animated:NO];
+    [UIView animateWithDuration:(animated ? 0.3 : 0.0)
+                          delay:0.0
+                        options:UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationCurveEaseInOut
+                     animations:^(void)
+                     {
+                         [self setZoom:newZoom];
+                         [self setCenterCoordinate:newCenter animated:NO];
 
-                             self.userTrackingMode = RMUserTrackingModeNone;
-                         }
-                         completion:nil];
-    } else {
-        [self setZoom:newZoom];
-        [self setCenterCoordinate:newCenter animated:NO];
-        
-        self.userTrackingMode = RMUserTrackingModeNone;
-    }
+                         self.userTrackingMode = RMUserTrackingModeNone;
+                     }
+                     completion:nil];
 }
 
 - (void)zoomByFactor:(float)zoomFactor near:(CGPoint)pivot animated:(BOOL)animated
@@ -1232,7 +1225,7 @@
             .y = northEastPoint.y - southWestPoint.y
         };
 
-        // Create the new zoom layout
+		// Create the new zoom layout
         RMProjectedRect zoomRect;
 
         // Default is with scale = 2.0 * mercators/pixel
@@ -1507,8 +1500,8 @@
     RMProjectedRect fittedProjectedRect = [self fitProjectedRect:normalizedProjectedRect intoRect:_constrainingProjectedBounds];
 
     RMProjectedPoint normalizedProjectedPoint;
-    normalizedProjectedPoint.x = fittedProjectedRect.origin.x + fabs(planetBounds.origin.x);
-    normalizedProjectedPoint.y = fittedProjectedRect.origin.y + fabs(planetBounds.origin.y);
+	normalizedProjectedPoint.x = fittedProjectedRect.origin.x + fabs(planetBounds.origin.x);
+	normalizedProjectedPoint.y = fittedProjectedRect.origin.y + fabs(planetBounds.origin.y);
 
     CGPoint correctedContentOffset = CGPointMake(normalizedProjectedPoint.x / currentMetersPerPixel,
                                                  aScrollView.contentSize.height - ((normalizedProjectedPoint.y / currentMetersPerPixel) + aScrollView.bounds.size.height));
@@ -2707,8 +2700,8 @@
 {
     RMProjectedRect planetBounds = _projection.planetBounds;
     RMProjectedPoint normalizedProjectedPoint;
-    normalizedProjectedPoint.x = projectedPoint.x + fabs(planetBounds.origin.x);
-    normalizedProjectedPoint.y = projectedPoint.y + fabs(planetBounds.origin.y);
+	normalizedProjectedPoint.x = projectedPoint.x + fabs(planetBounds.origin.x);
+	normalizedProjectedPoint.y = projectedPoint.y + fabs(planetBounds.origin.y);
 
     // \bug: There is a rounding error here for high zoom levels
     CGPoint projectedPixel = CGPointMake((normalizedProjectedPoint.x / _metersPerPixel) - _mapScrollView.contentOffset.x, (_mapScrollView.contentSize.height - (normalizedProjectedPoint.y / _metersPerPixel)) - _mapScrollView.contentOffset.y);
@@ -2781,27 +2774,27 @@
 
 - (CLLocationCoordinate2D)normalizeCoordinate:(CLLocationCoordinate2D)coordinate
 {
-    if (coordinate.longitude > 180.0)
+	if (coordinate.longitude > 180.0)
         coordinate.longitude -= 360.0;
 
-    coordinate.longitude /= 360.0;
-    coordinate.longitude += 0.5;
-    coordinate.latitude = 0.5 - ((log(tan((M_PI_4) + ((0.5 * M_PI * coordinate.latitude) / 180.0))) / M_PI) / 2.0);
+	coordinate.longitude /= 360.0;
+	coordinate.longitude += 0.5;
+	coordinate.latitude = 0.5 - ((log(tan((M_PI_4) + ((0.5 * M_PI * coordinate.latitude) / 180.0))) / M_PI) / 2.0);
 
-    return coordinate;
+	return coordinate;
 }
 
 - (RMTile)tileWithCoordinate:(CLLocationCoordinate2D)coordinate andZoom:(int)tileZoom
 {
-    int scale = (1<<tileZoom);
-    CLLocationCoordinate2D normalizedCoordinate = [self normalizeCoordinate:coordinate];
+	int scale = (1<<tileZoom);
+	CLLocationCoordinate2D normalizedCoordinate = [self normalizeCoordinate:coordinate];
 
-    RMTile returnTile;
-    returnTile.x = (int)(normalizedCoordinate.longitude * scale);
-    returnTile.y = (int)(normalizedCoordinate.latitude * scale);
-    returnTile.zoom = tileZoom;
+	RMTile returnTile;
+	returnTile.x = (int)(normalizedCoordinate.longitude * scale);
+	returnTile.y = (int)(normalizedCoordinate.latitude * scale);
+	returnTile.zoom = tileZoom;
 
-    return returnTile;
+	return returnTile;
 }
 
 - (RMSphericalTrapezium)latitudeLongitudeBoundingBoxForTile:(RMTile)aTile
@@ -2887,9 +2880,9 @@
 - (void)correctScreenPosition:(RMAnnotation *)annotation animated:(BOOL)animated
 {
     RMProjectedRect planetBounds = _projection.planetBounds;
-    RMProjectedPoint normalizedProjectedPoint;
-    normalizedProjectedPoint.x = annotation.projectedLocation.x + fabs(planetBounds.origin.x);
-    normalizedProjectedPoint.y = annotation.projectedLocation.y + fabs(planetBounds.origin.y);
+	RMProjectedPoint normalizedProjectedPoint;
+	normalizedProjectedPoint.x = annotation.projectedLocation.x + fabs(planetBounds.origin.x);
+	normalizedProjectedPoint.y = annotation.projectedLocation.y + fabs(planetBounds.origin.y);
 
     CGPoint newPosition = CGPointMake((normalizedProjectedPoint.x / _metersPerPixel) - _mapScrollView.contentOffset.x,
                                       _mapScrollView.contentSize.height - (normalizedProjectedPoint.y / _metersPerPixel) - _mapScrollView.contentOffset.y);
@@ -3302,7 +3295,7 @@
         default:
         {
             [_locationManager stopUpdatingHeading];
-            
+
             [CATransaction setAnimationDuration:0.5];
             [CATransaction setAnimationTimingFunction:[CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseInEaseOut]];
 

--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -360,7 +360,7 @@
 
 - (id)initWithFrame:(CGRect)frame andTilesource:(id <RMTileSource>)newTilesource
 {
-	return [self initWithFrame:frame
+    return [self initWithFrame:frame
                  andTilesource:newTilesource
               centerCoordinate:CLLocationCoordinate2DMake(kDefaultInitialLatitude, kDefaultInitialLongitude)
                      zoomLevel:kDefaultInitialZoomLevel
@@ -456,7 +456,7 @@
 
 - (void)handleMemoryWarningNotification:(NSNotification *)notification
 {
-	[self didReceiveMemoryWarning];
+    [self didReceiveMemoryWarning];
 }
 
 - (void)handleWillChangeOrientationNotification:(NSNotification *)notification
@@ -644,9 +644,9 @@
 
 - (NSString *)description
 {
-	CGRect bounds = self.bounds;
+    CGRect bounds = self.bounds;
 
-	return [NSString stringWithFormat:@"MapView at {%.0f,%.0f}-{%.0fx%.0f}", bounds.origin.x, bounds.origin.y, bounds.size.width, bounds.size.height];
+    return [NSString stringWithFormat:@"MapView at {%.0f,%.0f}-{%.0fx%.0f}", bounds.origin.x, bounds.origin.y, bounds.size.width, bounds.size.height];
 }
 
 #pragma mark -
@@ -654,7 +654,7 @@
 
 - (id <RMMapViewDelegate>)delegate
 {
-	return _delegate;
+    return _delegate;
 }
 
 - (void)setDelegate:(id <RMMapViewDelegate>)aDelegate
@@ -974,9 +974,9 @@
 //    RMLog(@"Current contentSize: {%.0f,%.0f}, zoom: %f", mapScrollView.contentSize.width, mapScrollView.contentSize.height, self.zoom);
 
     RMProjectedRect planetBounds = _projection.planetBounds;
-	RMProjectedPoint normalizedProjectedPoint;
-	normalizedProjectedPoint.x = centerProjectedPoint.x + fabs(planetBounds.origin.x);
-	normalizedProjectedPoint.y = centerProjectedPoint.y + fabs(planetBounds.origin.y);
+    RMProjectedPoint normalizedProjectedPoint;
+    normalizedProjectedPoint.x = centerProjectedPoint.x + fabs(planetBounds.origin.x);
+    normalizedProjectedPoint.y = centerProjectedPoint.y + fabs(planetBounds.origin.y);
 
     [_mapScrollView setContentOffset:CGPointMake(normalizedProjectedPoint.x / _metersPerPixel - _mapScrollView.bounds.size.width/2.0,
                                                 _mapScrollView.contentSize.height - ((normalizedProjectedPoint.y / _metersPerPixel) + _mapScrollView.bounds.size.height/2.0))
@@ -1032,9 +1032,9 @@
         boundsRect = [self fitProjectedRect:boundsRect intoRect:_constrainingProjectedBounds];
 
     RMProjectedRect planetBounds = _projection.planetBounds;
-	RMProjectedPoint normalizedProjectedPoint;
-	normalizedProjectedPoint.x = boundsRect.origin.x + fabs(planetBounds.origin.x);
-	normalizedProjectedPoint.y = boundsRect.origin.y + fabs(planetBounds.origin.y);
+    RMProjectedPoint normalizedProjectedPoint;
+    normalizedProjectedPoint.x = boundsRect.origin.x + fabs(planetBounds.origin.x);
+    normalizedProjectedPoint.y = boundsRect.origin.y + fabs(planetBounds.origin.y);
 
     float zoomScale = _mapScrollView.zoomScale;
     CGRect zoomRect = CGRectMake((normalizedProjectedPoint.x / _metersPerPixel) / zoomScale,
@@ -1067,17 +1067,24 @@
 
 - (void)setZoom:(float)newZoom atCoordinate:(CLLocationCoordinate2D)newCenter animated:(BOOL)animated
 {
-    [UIView animateWithDuration:(animated ? 0.3 : 0.0)
-                          delay:0.0
-                        options:UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationCurveEaseInOut
-                     animations:^(void)
-                     {
-                         [self setZoom:newZoom];
-                         [self setCenterCoordinate:newCenter animated:NO];
+    if (animated) {
+        [UIView animateWithDuration:(0.3)
+                              delay:0.0
+                            options:UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationCurveEaseInOut
+                         animations:^(void)
+                         {
+                             [self setZoom:newZoom];
+                             [self setCenterCoordinate:newCenter animated:NO];
 
-                         self.userTrackingMode = RMUserTrackingModeNone;
-                     }
-                     completion:nil];
+                             self.userTrackingMode = RMUserTrackingModeNone;
+                         }
+                         completion:nil];
+    } else {
+        [self setZoom:newZoom];
+        [self setCenterCoordinate:newCenter animated:NO];
+        
+        self.userTrackingMode = RMUserTrackingModeNone;
+    }
 }
 
 - (void)zoomByFactor:(float)zoomFactor near:(CGPoint)pivot animated:(BOOL)animated
@@ -1225,7 +1232,7 @@
             .y = northEastPoint.y - southWestPoint.y
         };
 
-		// Create the new zoom layout
+        // Create the new zoom layout
         RMProjectedRect zoomRect;
 
         // Default is with scale = 2.0 * mercators/pixel
@@ -1500,8 +1507,8 @@
     RMProjectedRect fittedProjectedRect = [self fitProjectedRect:normalizedProjectedRect intoRect:_constrainingProjectedBounds];
 
     RMProjectedPoint normalizedProjectedPoint;
-	normalizedProjectedPoint.x = fittedProjectedRect.origin.x + fabs(planetBounds.origin.x);
-	normalizedProjectedPoint.y = fittedProjectedRect.origin.y + fabs(planetBounds.origin.y);
+    normalizedProjectedPoint.x = fittedProjectedRect.origin.x + fabs(planetBounds.origin.x);
+    normalizedProjectedPoint.y = fittedProjectedRect.origin.y + fabs(planetBounds.origin.y);
 
     CGPoint correctedContentOffset = CGPointMake(normalizedProjectedPoint.x / currentMetersPerPixel,
                                                  aScrollView.contentSize.height - ((normalizedProjectedPoint.y / currentMetersPerPixel) + aScrollView.bounds.size.height));
@@ -2700,8 +2707,8 @@
 {
     RMProjectedRect planetBounds = _projection.planetBounds;
     RMProjectedPoint normalizedProjectedPoint;
-	normalizedProjectedPoint.x = projectedPoint.x + fabs(planetBounds.origin.x);
-	normalizedProjectedPoint.y = projectedPoint.y + fabs(planetBounds.origin.y);
+    normalizedProjectedPoint.x = projectedPoint.x + fabs(planetBounds.origin.x);
+    normalizedProjectedPoint.y = projectedPoint.y + fabs(planetBounds.origin.y);
 
     // \bug: There is a rounding error here for high zoom levels
     CGPoint projectedPixel = CGPointMake((normalizedProjectedPoint.x / _metersPerPixel) - _mapScrollView.contentOffset.x, (_mapScrollView.contentSize.height - (normalizedProjectedPoint.y / _metersPerPixel)) - _mapScrollView.contentOffset.y);
@@ -2774,27 +2781,27 @@
 
 - (CLLocationCoordinate2D)normalizeCoordinate:(CLLocationCoordinate2D)coordinate
 {
-	if (coordinate.longitude > 180.0)
+    if (coordinate.longitude > 180.0)
         coordinate.longitude -= 360.0;
 
-	coordinate.longitude /= 360.0;
-	coordinate.longitude += 0.5;
-	coordinate.latitude = 0.5 - ((log(tan((M_PI_4) + ((0.5 * M_PI * coordinate.latitude) / 180.0))) / M_PI) / 2.0);
+    coordinate.longitude /= 360.0;
+    coordinate.longitude += 0.5;
+    coordinate.latitude = 0.5 - ((log(tan((M_PI_4) + ((0.5 * M_PI * coordinate.latitude) / 180.0))) / M_PI) / 2.0);
 
-	return coordinate;
+    return coordinate;
 }
 
 - (RMTile)tileWithCoordinate:(CLLocationCoordinate2D)coordinate andZoom:(int)tileZoom
 {
-	int scale = (1<<tileZoom);
-	CLLocationCoordinate2D normalizedCoordinate = [self normalizeCoordinate:coordinate];
+    int scale = (1<<tileZoom);
+    CLLocationCoordinate2D normalizedCoordinate = [self normalizeCoordinate:coordinate];
 
-	RMTile returnTile;
-	returnTile.x = (int)(normalizedCoordinate.longitude * scale);
-	returnTile.y = (int)(normalizedCoordinate.latitude * scale);
-	returnTile.zoom = tileZoom;
+    RMTile returnTile;
+    returnTile.x = (int)(normalizedCoordinate.longitude * scale);
+    returnTile.y = (int)(normalizedCoordinate.latitude * scale);
+    returnTile.zoom = tileZoom;
 
-	return returnTile;
+    return returnTile;
 }
 
 - (RMSphericalTrapezium)latitudeLongitudeBoundingBoxForTile:(RMTile)aTile
@@ -2880,9 +2887,9 @@
 - (void)correctScreenPosition:(RMAnnotation *)annotation animated:(BOOL)animated
 {
     RMProjectedRect planetBounds = _projection.planetBounds;
-	RMProjectedPoint normalizedProjectedPoint;
-	normalizedProjectedPoint.x = annotation.projectedLocation.x + fabs(planetBounds.origin.x);
-	normalizedProjectedPoint.y = annotation.projectedLocation.y + fabs(planetBounds.origin.y);
+    RMProjectedPoint normalizedProjectedPoint;
+    normalizedProjectedPoint.x = annotation.projectedLocation.x + fabs(planetBounds.origin.x);
+    normalizedProjectedPoint.y = annotation.projectedLocation.y + fabs(planetBounds.origin.y);
 
     CGPoint newPosition = CGPointMake((normalizedProjectedPoint.x / _metersPerPixel) - _mapScrollView.contentOffset.x,
                                       _mapScrollView.contentSize.height - (normalizedProjectedPoint.y / _metersPerPixel) - _mapScrollView.contentOffset.y);
@@ -3295,7 +3302,7 @@
         default:
         {
             [_locationManager stopUpdatingHeading];
-
+            
             [CATransaction setAnimationDuration:0.5];
             [CATransaction setAnimationTimingFunction:[CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseInEaseOut]];
 

--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -1067,18 +1067,26 @@
 
 - (void)setZoom:(float)newZoom atCoordinate:(CLLocationCoordinate2D)newCenter animated:(BOOL)animated
 {
-    [UIView animateWithDuration:(animated ? 0.3 : 0.0)
-                          delay:0.0
-                        options:UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationCurveEaseInOut
-                     animations:^(void)
-                     {
-                         [self setZoom:newZoom];
-                         [self setCenterCoordinate:newCenter animated:NO];
+    if (animated) {
+        [UIView animateWithDuration:(0.3)
+                              delay:0.0
+                            options:UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationCurveEaseInOut
+                         animations:^(void)
+                         {
+                             [self setZoom:newZoom];
+                             [self setCenterCoordinate:newCenter animated:NO];
 
-                         self.userTrackingMode = RMUserTrackingModeNone;
-                     }
-                     completion:nil];
+                             self.userTrackingMode = RMUserTrackingModeNone;
+                         }
+                         completion:nil];
+    } else {
+        [self setZoom:newZoom];
+        [self setCenterCoordinate:newCenter animated:NO];
+        
+        self.userTrackingMode = RMUserTrackingModeNone;
+    }
 }
+
 
 - (void)zoomByFactor:(float)zoomFactor near:(CGPoint)pivot animated:(BOOL)animated
 {


### PR DESCRIPTION
For the details please see my post here: http://support.mapbox.com/discussions/mapbox-ios-sdk/3157-rendering-maps-in-background-or-advice-needed

This fix is to prevent from random crashes during background rendering of RMMapView 

Sorry for dirty commits, this is due to a lot of unnecessary formatting changes in the first commit. Only the last commit makes sense.
