### PR TITLE
Remove GCC 'uninitialized variables' warning flag in favor of LLVM warning

### DIFF
--- a/MapView/MapView.xcodeproj/project.pbxproj
+++ b/MapView/MapView.xcodeproj/project.pbxproj
@@ -1004,6 +1004,7 @@
 					"\"$(SRCROOT)/Map/GRMustache/lib\"",
 					"\"$(SRCROOT)/../Proj4\"",
 				);
+				OTHER_CFLAGS = "";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = Mapbox;
 				RUN_CLANG_STATIC_ANALYZER = NO;


### PR DESCRIPTION
- Wuninitialized required Optimized flag (O) and optimizations made debugging and testing frustrating.
  LLVM warnings for initialized vars are turned on by default so we are not losing any compiler help by
  doing this assuming use of "modern" development environment (i.e. Xcode 4 / 5, clang, etc)

Optimizations are also turned on for release build. This change just helps us debug and test in debug build by keeping symbols.
