### PR TITLE
Add asynchronous means of mapbox source creation.

### DIFF
--- a/MapView/Map/RMMapboxSource.h
+++ b/MapView/Map/RMMapboxSource.h
@@ -54,11 +54,23 @@ typedef enum : NSUInteger {
 } RMMapboxSourceQuality;
 
 @class RMMapView;
+@class RMMapboxSource;
+
+typedef void(^tileSourceCreationCallback)(RMMapboxSource *source, NSError *error);
 
 /** An RMMapboxSource is used to display map tiles from a network-based map hosted on [Mapbox](http://mapbox.com/plans) or the open source [TileStream](https://github.com/mapbox/tilestream) software. Maps are referenced by their Mapbox map ID or by a file or URL containing [TileJSON](http://mapbox.com/developers/tilejson/). */
 @interface RMMapboxSource : RMAbstractWebMapSource
 
 /** @name Creating Tile Sources */
+
+/** Initialize a tile source asynchronously and return it in a
+callback method.
+
+@param mapID The Mapbox map ID string, typically in the format `<username>.map-<random characters>`.
+@param enableSSL Whether to use SSL-enabled HTTPS connections for map tiles and other related data.
+@param callback The callback block to execute. */
++ (void)createSourceAsynchronouslyWithMapID:(NSString *)mapID enableSSL: (BOOL)enableSSL callback:(tileSourceCreationCallback)callBack;
+
 
 /** Initialize a tile source using the Mapbox map ID.
 *


### PR DESCRIPTION
This change allows for the creation of a mapbox source without forcing the use of `NSString+RMUserAgent brandedStringWithContentsOfURL:encoding:error` which, in turn, makes an `NSURLConnection sendSynchronousRequest...` request call (to get tile JSON) that blocks the main thread. For my use case at least, that synchronous call  is not tolerable. And, since it is done in a category on NSString it is not currently very clear to users of the API that mapbox source initialization uses the network in a blocking manner.

This PR also adds two internal methods that are used by the new asynchronous call and existing initializers. They introduce no new functionality and are just there to dry up new and existing implementations.

This new API allows us to create a map while retaining control of the main thread. In addition, it is possible to obtain error reporting related to source initialization failure due to tile JSON network or application errors.

A concrete example of usage:

```
    [RMMapboxSource createSourceAsynchronouslyWithMapID:@"boundsj.barrachoinchicago" enableSSL:NO callback:^(RMMapboxSource *source, NSError *error) {
        if (error) {
            [[[UIAlertView alloc] initWithTitle:@"No Map 4 U!" message:[error localizedDescription] delegate:nil cancelButtonTitle:@"shucks" otherButtonTitles:nil] show];
            return;
        }
        RMMapView *map = [[RMMapView alloc] initWithFrame:self.mapView.frame andTilesource:source];
        map.centerCoordinate = CLLocationCoordinate2DMake(41.8419, -87.6805);;
        map.zoom = 10.8;
        map.maxZoom = 14.0;
        map.minZoom = 10.0;
        [self.mapView addSubview:map];
    }];
```

Also, it might be worth noting that this change has unit tests on a different branch (I did not want to introduce them here since there is no precedent for it). Those tests can be found [here.](https://github.com/boundsj/mapbox-ios-sdk/blob/tests/MapView/Specs/RMMapboxSourceSpec.mm)
