### PR TITLE
Exclude database cache file from iCloud backup

### DIFF
--- a/MapView/Map/RMDatabaseCache.h
+++ b/MapView/Map/RMDatabaseCache.h
@@ -76,4 +76,9 @@
 /** The current file size of the database cache on disk. */
 - (unsigned long long)fileSize;
 
+/** Set a flag to include the database in automatic iCloud backups.  (The default during database creation is to exclude.)
+ 
+*   @param include If YES, the database will be included in automatic iCloud backups. */
+- (void)includeInBackup:(BOOL)include;
+
 @end

--- a/MapView/Map/RMDatabaseCache.m
+++ b/MapView/Map/RMDatabaseCache.m
@@ -134,8 +134,6 @@
 
     _tileCount = [self countTiles];
 
-    [[NSURL.alloc initFileURLWithPath:path] setResourceValue:@(YES) forKey:NSURLIsExcludedFromBackupKey error:nil];
-
 	return self;	
 }
 

--- a/MapView/Map/RMDatabaseCache.m
+++ b/MapView/Map/RMDatabaseCache.m
@@ -130,11 +130,17 @@
         [db setShouldCacheStatements:TRUE];
     }];
 
+    [self includeInBackup:NO];
 	[self configureDBForFirstUse];
 
     _tileCount = [self countTiles];
 
 	return self;	
+}
+
+- (void)includeInBackup:(BOOL)include
+{
+    [[NSURL.alloc initFileURLWithPath:self.databasePath] setResourceValue:@(!include) forKey:NSURLIsExcludedFromBackupKey error:nil];
 }
 
 - (id)initUsingCacheDir:(BOOL)useCacheDir

--- a/MapView/Map/RMDatabaseCache.m
+++ b/MapView/Map/RMDatabaseCache.m
@@ -134,6 +134,8 @@
 
     _tileCount = [self countTiles];
 
+    [[NSURL.alloc initFileURLWithPath:path] setResourceValue:@(YES) forKey:NSURLIsExcludedFromBackupKey error:nil];
+
 	return self;	
 }
 

--- a/MapView/Map/RMTileCache.h
+++ b/MapView/Map/RMTileCache.h
@@ -163,4 +163,8 @@ typedef enum : short {
 *   This method returns immediately so as to not block the calling thread. If you wish to be notified of the actual cancellation completion, implement the tileCacheDidCancelBackgroundCache: delegate method. */
 - (void)cancelBackgroundCache;
 
+/** Tells a tile cache whether or not to include database cache file(s) in iCloud backups. (The default when a tile cache is initiailized is to not backup.)
+*   @param include Boolean value indicating whether or not to include the database cache file(s) in iCloud backups. */
+- (void)includeDatabaseCachesInBackup:(BOOL)include;
+
 @end

--- a/MapView/Map/RMTileCache.m
+++ b/MapView/Map/RMTileCache.m
@@ -375,6 +375,13 @@
     });
 }
 
+- (void)includeDatabaseCachesInBackup:(BOOL)include
+{
+    for (id <RMTileCache> cache in _tileCaches)
+        if ([cache isKindOfClass:[RMDatabaseCache class]])
+            [(RMDatabaseCache*)cache includeInBackup:include];
+}
+
 @end
 
 #pragma mark -


### PR DESCRIPTION
My app was initially rejected because the `RMDatabaseCache` file was being backed up to iCloud.  Adding a line of code to exclude the file from backups resolved the problem.
