### PR TITLE
Exclude db cache from iCloud backup, with option to include

### DIFF
--- a/MapView/Map/RMDatabaseCache.h
+++ b/MapView/Map/RMDatabaseCache.h
@@ -76,4 +76,9 @@
 /** The current file size of the database cache on disk. */
 - (unsigned long long)fileSize;
 
+/** Set a flag to include the database in automatic iCloud backups.  (The default during database creation is to exclude.)
+ 
+*   @param include If YES, the database will be included in automatic iCloud backups. */
+- (void)includeInBackup:(BOOL)include;
+
 @end

--- a/MapView/Map/RMDatabaseCache.m
+++ b/MapView/Map/RMDatabaseCache.m
@@ -134,8 +134,6 @@
 
     _tileCount = [self countTiles];
 
-    [[NSURL.alloc initFileURLWithPath:path] setResourceValue:@(YES) forKey:NSURLIsExcludedFromBackupKey error:nil];
-
 	return self;	
 }
 

--- a/MapView/Map/RMDatabaseCache.m
+++ b/MapView/Map/RMDatabaseCache.m
@@ -130,11 +130,17 @@
         [db setShouldCacheStatements:TRUE];
     }];
 
+    [self includeInBackup:NO];
 	[self configureDBForFirstUse];
 
     _tileCount = [self countTiles];
 
 	return self;	
+}
+
+- (void)includeInBackup:(BOOL)include
+{
+    [[NSURL.alloc initFileURLWithPath:self.databasePath] setResourceValue:@(!include) forKey:NSURLIsExcludedFromBackupKey error:nil];
 }
 
 - (id)initUsingCacheDir:(BOOL)useCacheDir

--- a/MapView/Map/RMDatabaseCache.m
+++ b/MapView/Map/RMDatabaseCache.m
@@ -134,6 +134,8 @@
 
     _tileCount = [self countTiles];
 
+    [[NSURL.alloc initFileURLWithPath:path] setResourceValue:@(YES) forKey:NSURLIsExcludedFromBackupKey error:nil];
+
 	return self;	
 }
 

--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -1362,9 +1362,16 @@
     longPressRecognizer.allowableMovement = MAXFLOAT;
     longPressRecognizer.delegate = self;
 
+    UILongPressGestureRecognizer *doubleTapAndHoldRecognizer = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(handleDoubleTapAndHold:)];
+    doubleTapAndHoldRecognizer.numberOfTapsRequired = 1; // Double-tap.
+    doubleTapAndHoldRecognizer.minimumPressDuration = 0.1;
+    doubleTapAndHoldRecognizer.allowableMovement = MAXFLOAT;  // We don't really care how far apart the two taps are.
+    doubleTapAndHoldRecognizer.delegate = self;
+    
     [self addGestureRecognizer:singleTapRecognizer];
     [self addGestureRecognizer:doubleTapRecognizer];
     [self addGestureRecognizer:longPressRecognizer];
+    [self addGestureRecognizer:doubleTapAndHoldRecognizer];
 
     // two finger taps
     UITapGestureRecognizer *twoFingerSingleTapRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTwoFingerSingleTap:)];
@@ -1844,6 +1851,26 @@
         // pass map long-press to delegate
         //
         [_delegate longPressOnMap:self at:[recognizer locationInView:self]];
+    }
+}
+
+- (void)handleDoubleTapAndHold:(UILongPressGestureRecognizer *)recognizer
+{
+    // Handle gesture to double-tap and drag up and down to zoom in and out:
+    switch (recognizer.state)
+    {
+        case UIGestureRecognizerStateBegan:
+        {
+            zoomTapStartY = [recognizer locationInView:self].y;
+            zoomTapStartingZoom = self.zoom;
+        }
+        case UIGestureRecognizerStateChanged:
+        {
+            float zoomDiff = ([recognizer locationInView:self].y - zoomTapStartY) / ZOOM_GESTURE_SCALE_FACTOR;
+            float newZoom = zoomTapStartingZoom + zoomDiff;
+            [self setZoom:newZoom];
+            break;
+        }
     }
 }
 

--- a/MapView/Map/RMTileCache.h
+++ b/MapView/Map/RMTileCache.h
@@ -163,4 +163,8 @@ typedef enum : short {
 *   This method returns immediately so as to not block the calling thread. If you wish to be notified of the actual cancellation completion, implement the tileCacheDidCancelBackgroundCache: delegate method. */
 - (void)cancelBackgroundCache;
 
+/** Tells a tile cache whether or not to include database cache file(s) in iCloud backups. (The default when a tile cache is initiailized is to not backup.)
+*   @param include Boolean value indicating whether or not to include the database cache file(s) in iCloud backups. */
+- (void)includeDatabaseCachesInBackup:(BOOL)include;
+
 @end

--- a/MapView/Map/RMTileCache.m
+++ b/MapView/Map/RMTileCache.m
@@ -375,6 +375,13 @@
     });
 }
 
+- (void)includeDatabaseCachesInBackup:(BOOL)include
+{
+    for (id <RMTileCache> cache in _tileCaches)
+        if ([cache isKindOfClass:[RMDatabaseCache class]])
+            [(RMDatabaseCache*)cache includeInBackup:include];
+}
+
 @end
 
 #pragma mark -


### PR DESCRIPTION
With this change, the db cache will be excluded from iCloud backups by default when the cache is created.  A method in `RMDatabaseCache` called `includeInBackup:` can be used to include the file.  Also, a method in `RMTileCache` called `includeDatabaseCachesInBackup:` is provided to set the backup flag appropriately for all db caches contained in the tile cache.

More background information is in [#404](https://github.com/mapbox/mapbox-ios-sdk/pull/404).
