### PR TITLE
Correctly update constraints on frame change

### DIFF
--- a/MapView/Map/RMFoundation.c
+++ b/MapView/Map/RMFoundation.c
@@ -151,6 +151,13 @@ bool RMProjectedRectIsZero(RMProjectedRect rect)
     return (rect.origin.x == 0.0) && (rect.origin.y == 0.0) && (rect.size.width == 0.0) && (rect.size.height == 0.0);
 }
 
+bool RMProjectedRectEqualToProjectedRect(RMProjectedRect rect1, RMProjectedRect rect2)
+{
+	return RMProjectedPointEqualToProjectedPoint(rect1.origin, rect2.origin) &&
+        rect1.size.width == rect2.size.width &&
+        rect1.size.height == rect2.size.height;
+}
+
 #if !defined (RMMIN)
 #define RMMIN(a,b)  ((a) < (b) ? (a) : (b))
 #endif

--- a/MapView/Map/RMFoundation.h
+++ b/MapView/Map/RMFoundation.h
@@ -53,13 +53,24 @@ typedef struct {
 	RMProjectedSize size;
 } RMProjectedRect;
 
-#if __OBJC__
+#ifdef __OBJC__
 /*! \struct RMSphericalTrapezium
  \brief a rectangle, specified by two corner coordinates */
 typedef struct {
 	CLLocationCoordinate2D southWest;
 	CLLocationCoordinate2D northEast;
 } RMSphericalTrapezium;
+static inline RMSphericalTrapezium RMSphericalTrapeziumIntersection(RMSphericalTrapezium box1, RMSphericalTrapezium box2){
+    return ((RMSphericalTrapezium) {
+        .northEast = {
+            .latitude = MIN(box1.northEast.latitude, box2.northEast.latitude),
+            .longitude = MIN(box1.northEast.longitude, box2.northEast.longitude)},
+        .southWest = {
+            .latitude = MAX(box1.southWest.latitude, box2.southWest.latitude),
+            .longitude = MAX(box1.southWest.longitude, box2.southWest.longitude)
+        }
+    });
+}
 #endif
 
 #pragma mark -

--- a/MapView/Map/RMFoundation.h
+++ b/MapView/Map/RMFoundation.h
@@ -72,6 +72,7 @@ RMProjectedRect  RMTranslateProjectedRectBy(RMProjectedRect rect, RMProjectedSiz
 #pragma mark -
 
 bool RMProjectedPointEqualToProjectedPoint(RMProjectedPoint point1, RMProjectedPoint point2);
+bool RMProjectedRectEqualToProjectedRect(RMProjectedRect rect1, RMProjectedRect rect2);
 
 bool RMProjectedRectIntersectsProjectedRect(RMProjectedRect rect1, RMProjectedRect rect2);
 bool RMProjectedRectContainsProjectedRect(RMProjectedRect rect1, RMProjectedRect rect2);

--- a/MapView/Map/RMMapView.h
+++ b/MapView/Map/RMMapView.h
@@ -282,8 +282,6 @@ typedef enum : NSUInteger {
 *   @param northEast The northeast point to constrain to. */
 - (void)setConstraintsSouthWest:(CLLocationCoordinate2D)southWest northEast:(CLLocationCoordinate2D)northEast;
 
-- (void)setProjectedConstraintsSouthWest:(RMProjectedPoint)southWest northEast:(RMProjectedPoint)northEast;
-
 #pragma mark - Snapshots
 
 /** @name Capturing Snapshots of the Map View */

--- a/MapView/Map/RMTileSourcesContainer.m
+++ b/MapView/Map/RMTileSourcesContainer.m
@@ -56,8 +56,8 @@
     _mercatorToTileProjection = nil;
 
     _latitudeLongitudeBoundingBox = ((RMSphericalTrapezium) {
-        .northEast = {.latitude = 90.0, .longitude = 180.0},
-        .southWest = {.latitude = -90.0, .longitude = -180.0}
+        .northEast = {.latitude = INT_MIN, .longitude = INT_MIN},
+        .southWest = {.latitude = INT_MAX, .longitude = INT_MAX}
     });
 
     _minZoom = kRMTileSourcesContainerMaxZoom;
@@ -74,8 +74,8 @@
     [_tileSourcesLock lock];
 
     _latitudeLongitudeBoundingBox = ((RMSphericalTrapezium) {
-        .northEast = {.latitude = 90.0, .longitude = 180.0},
-        .southWest = {.latitude = -90.0, .longitude = -180.0}
+        .northEast = {.latitude = INT_MIN, .longitude = INT_MIN},
+        .southWest = {.latitude = INT_MAX, .longitude = INT_MAX}
     });
 
     for (id <RMTileSource>tileSource in _tileSources)
@@ -84,11 +84,11 @@
 
         _latitudeLongitudeBoundingBox = ((RMSphericalTrapezium) {
             .northEast = {
-                .latitude = MIN(_latitudeLongitudeBoundingBox.northEast.latitude, newLatitudeLongitudeBoundingBox.northEast.latitude),
-                .longitude = MIN(_latitudeLongitudeBoundingBox.northEast.longitude, newLatitudeLongitudeBoundingBox.northEast.longitude)},
+                .latitude = MAX(_latitudeLongitudeBoundingBox.northEast.latitude, newLatitudeLongitudeBoundingBox.northEast.latitude),
+                .longitude = MAX(_latitudeLongitudeBoundingBox.northEast.longitude, newLatitudeLongitudeBoundingBox.northEast.longitude)},
             .southWest = {
-                .latitude = MAX(_latitudeLongitudeBoundingBox.southWest.latitude, newLatitudeLongitudeBoundingBox.southWest.latitude),
-                .longitude = MAX(_latitudeLongitudeBoundingBox.southWest.longitude, newLatitudeLongitudeBoundingBox.southWest.longitude)
+                .latitude = MIN(_latitudeLongitudeBoundingBox.southWest.latitude, newLatitudeLongitudeBoundingBox.southWest.latitude),
+                .longitude = MIN(_latitudeLongitudeBoundingBox.southWest.longitude, newLatitudeLongitudeBoundingBox.southWest.longitude)
             }
         });
     }
@@ -231,7 +231,7 @@
     BOOL intersects = (((minX1 <= minX2 && minX2 <= maxX1) || (minX2 <= minX1 && minX1 <= maxX2)) &&
                        ((minY1 <= minY2 && minY2 <= maxY1) || (minY2 <= minY1 && minY1 <= maxY2)));
 
-    if ( ! intersects)
+    if ([_tileSources count] > 0 &&  ! intersects)
     {
         NSLog(@"The bounding box from tilesource '%@' doesn't intersect with the tilesource containers' bounding box", [tileSource shortName]);
         [_tileSourcesLock unlock];
@@ -240,11 +240,11 @@
 
     _latitudeLongitudeBoundingBox = ((RMSphericalTrapezium) {
         .northEast = {
-            .latitude = MIN(_latitudeLongitudeBoundingBox.northEast.latitude, newLatitudeLongitudeBoundingBox.northEast.latitude),
-            .longitude = MIN(_latitudeLongitudeBoundingBox.northEast.longitude, newLatitudeLongitudeBoundingBox.northEast.longitude)},
+            .latitude = MAX(_latitudeLongitudeBoundingBox.northEast.latitude, newLatitudeLongitudeBoundingBox.northEast.latitude),
+            .longitude = MAX(_latitudeLongitudeBoundingBox.northEast.longitude, newLatitudeLongitudeBoundingBox.northEast.longitude)},
         .southWest = {
-            .latitude = MAX(_latitudeLongitudeBoundingBox.southWest.latitude, newLatitudeLongitudeBoundingBox.southWest.latitude),
-            .longitude = MAX(_latitudeLongitudeBoundingBox.southWest.longitude, newLatitudeLongitudeBoundingBox.southWest.longitude)
+            .latitude = MIN(_latitudeLongitudeBoundingBox.southWest.latitude, newLatitudeLongitudeBoundingBox.southWest.latitude),
+            .longitude = MIN(_latitudeLongitudeBoundingBox.southWest.longitude, newLatitudeLongitudeBoundingBox.southWest.longitude)
         }
     });
 
@@ -337,8 +337,8 @@
      _mercatorToTileProjection = nil;
 
     _latitudeLongitudeBoundingBox = ((RMSphericalTrapezium) {
-        .northEast = {.latitude = 90.0, .longitude = 180.0},
-        .southWest = {.latitude = -90.0, .longitude = -180.0}
+        .northEast = {.latitude = INT_MIN, .longitude = INT_MIN},
+        .southWest = {.latitude = INT_MAX, .longitude = INT_MAX}
     });
 
     _minZoom = kRMTileSourcesContainerMaxZoom;


### PR DESCRIPTION
When using a source with a bounding box smaller than the world box, you can see that it does not update correctly upon device rotation or frame size change.
This is because `_constrainingProjectedBounds` should be updated when frame changes.
This PR fixes this.
You can test it with [this mbtiles](http://www.sendspace.com/file/kztjoy)

Now i also added something else in that PR. Today when setting multiple tile sources, the "tile source bounding box" is set to the intersection of all sources boxes. It seems to be it should be the union.

Why would i use multiple tile sources? For exemple i could do it to have offline/online support with a mbtiles. The mbtiles gives me offline support but has a limited region. So if i had another "online" source, i can have navigation without the user seeing the difference.
But now i put the 2 tile sources together i obviously want to be able to navigate inside the union of the 2 boxes. The only problem would be if those boxes did not intersect because you would have empty tiles every where. But i  feel like it s a different problem.
