### PR TITLE
Animation of layers during zoomToRect:animated:

### DIFF
--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -1047,6 +1047,8 @@
                                  ((planetBounds.size.height - normalizedProjectedPoint.y - boundsRect.size.height) / _metersPerPixel) / zoomScale,
                                  (boundsRect.size.width / _metersPerPixel) / zoomScale,
                                  (boundsRect.size.height / _metersPerPixel) / zoomScale);
+    float newZoom = log2f(zoomScale);
+    _animationZoomFactor = exp2f(newZoom - [self zoom]);
     [_mapScrollView zoomToRect:zoomRect animated:animated];
 }
 

--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -213,6 +213,8 @@
     SMCalloutView *_currentCallout;
 
     BOOL _rotateAtMinZoom;
+    
+    float _animationZoomFactor;
 }
 
 @synthesize decelerationMode = _decelerationMode;
@@ -1132,6 +1134,7 @@
                                      ((_mapScrollView.contentOffset.y + pivot.y) - (newZoomSize.height * factorY)) / zoomScale,
                                      newZoomSize.width / zoomScale,
                                      newZoomSize.height / zoomScale);
+        _animationZoomFactor = zoomFactor;
         [_mapScrollView zoomToRect:zoomRect animated:animated];
     }
     else
@@ -2902,7 +2905,7 @@
     if (animated && !_mapScrollView.isZooming)
     {
         [CATransaction setAnimationTimingFunction:[CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseInEaseOut]];
-        [CATransaction setAnimationDuration:0.30];
+        [CATransaction setAnimationDuration:((_animationZoomFactor > 1)?_animationZoomFactor:1/_animationZoomFactor) * 0.15];
     }
     else
     {


### PR DESCRIPTION
if currently in a "float" zoom value, when using double tap of tap with two fingers, zoomToRect:animated: is called with a factor != 2. This will cause the zoomToRect:animated: animation duration to be different from 30ms.
That PR fixes correctPositionOfAllAnnotationsIncludingInvisibles to take that into account.
To test it simply zoom a little bit with a pinch gesture. Then double tap.
- before : layers doesn't animate correctly
- after: they do
