### PR TITLE
Checking if need to add constraints for logoBug.

### DIFF
--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -536,7 +536,7 @@
         }
     }
 
-    if (_logoBug)
+    if (_showLogoBug && _logoBug)
     {
         if ( ! [[viewController.view valueForKeyPath:@"constraints.firstItem"]  containsObject:_logoBug] &&
              ! [[viewController.view valueForKeyPath:@"constraints.secondItem"] containsObject:_logoBug])


### PR DESCRIPTION
Checking if really need (not only existence of logoBug UIImage, but also value of _showLogoBug should be YES) to add constraints for logoBug UIImage. If set _showLogoBug to NO without this fix - exception about adding constraints for element that not exists in view hierarchy fires.
