### PR TITLE
Fix for partial caching of layered web tiles.

### DIFF
--- a/MapView/Map/RMAbstractWebMapSource.m
+++ b/MapView/Map/RMAbstractWebMapSource.m
@@ -84,6 +84,7 @@
     });
 
     NSArray *URLs = [self URLsForTile:tile];
+    NSUInteger numTileImagesLoaded = 0;
 
     if ([URLs count] == 0)
     {
@@ -151,6 +152,7 @@
                 {
                     image = [UIImage imageWithData:tileData];
                 }
+                numTileImagesLoaded = numTileImagesLoaded + 1;
             }
         }
     }
@@ -166,9 +168,10 @@
             if (response.statusCode == HTTP_404_NOT_FOUND)
                 break;
         }
+        numTileImagesLoaded = 1;
     }
 
-    if (image && self.isCacheable)
+    if (image && self.isCacheable && numTileImagesLoaded == [URLs count])
         [tileCache addImage:image forTile:tile withCacheKey:[self uniqueTilecacheKey]];
 
     dispatch_async(dispatch_get_main_queue(), ^(void)

--- a/MapView/Map/RMMapView.h
+++ b/MapView/Map/RMMapView.h
@@ -213,6 +213,9 @@ typedef enum : NSUInteger {
 /** The current zoom level of the map. */
 @property (nonatomic, assign) float zoom;
 
+/** A Boolean value denoting if the map is zooming (either programmatically ob by double tap / two finger tap) */
+@property (nonatomic, readonly) BOOL mapScrollViewIsZooming;
+
 /** The minimum zoom level of the map, clamped to the range supported by the tile source(s). */
 @property (nonatomic, assign) float minZoom;
 

--- a/MapView/Map/RMMapView.h
+++ b/MapView/Map/RMMapView.h
@@ -122,6 +122,12 @@ typedef enum : NSUInteger {
 /** Take missing tiles from lower-numbered zoom levels, up to a given number of zoom levels. This can be used in order to increase perceived tile load performance or to allow zooming in beyond levels supported natively by a given tile source. Defaults to 1. */
 @property (nonatomic, assign) NSUInteger missingTilesDepth;
 
+/** The scroll view containing the map tiles */
+@property (nonatomic, assign, readonly) RMMapScrollView *mapScrollView;
+
+/** The view used for map overlays like annotations */
+@property (nonatomic, assign, readonly) RMMapOverlayView *overlayView;
+
 /** A custom, static view to use behind the map tiles. The default behavior is to use grid imagery that moves with map panning like MapKit. */
 @property (nonatomic, strong) UIView *backgroundView;
 

--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -2337,6 +2337,16 @@
 
 #pragma mark - Properties
 
+- (RMMapScrollView *)mapScrollView
+{
+    return _mapScrollView;
+}
+
+- (RMMapOverlayView *)overlayView
+{
+    return _overlayView;
+}
+
 - (UIView *)backgroundView
 {
     return _backgroundView;

--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -179,7 +179,6 @@
     float _zoom, _lastZoom;
     CGPoint _lastContentOffset, _accumulatedDelta;
     CGSize _lastContentSize;
-    BOOL _mapScrollViewIsZooming;
 
     BOOL _draggingEnabled, _bouncingEnabled;
 
@@ -218,6 +217,7 @@
 @synthesize decelerationMode = _decelerationMode;
 
 @synthesize zoomingInPivotsAroundCenter = _zoomingInPivotsAroundCenter;
+@synthesize mapScrollViewIsZooming = _mapScrollViewIsZooming;
 @synthesize minZoom = _minZoom, maxZoom = _maxZoom;
 @synthesize screenScale = _screenScale;
 @synthesize tileCache = _tileCache;


### PR DESCRIPTION
There is a caching problem with layered web tile sources  (like OpenStreetMap with an OpenSeaMap Overlay). If not all of the layers are loaded successfully, the resulting composite image still gets cached and is not reloaded on the next display. This may happen if one of the layer servers times out. For us this resulted in cached tiles with only the transparent OpenSeaMap layer being displayed for quite some time.
This proposed fix counts the downloaded tile images and checks if all images have been successfully downloaded before adding the composite image to the cache.
