### PR TITLE
SMCalloutView contentView property setting implementation for RMMapLayer

### DIFF
--- a/MapView/Map/RMMapLayer.h
+++ b/MapView/Map/RMMapLayer.h
@@ -99,6 +99,13 @@
 *   If the view you specify is also a descendant of the UIControl class, you can use the map view’s delegate to receive notifications when your control is tapped. If it does not descend from UIControl, your view is responsible for handling any touch events within its bounds. */
 @property (nonatomic, strong) UIView *rightCalloutAccessoryView;
 
+/**
+ * Custom "content" view that can be any width/height.
+ *
+ * If this is set, title/subtitle/titleView/subtitleView are all ignored.
+ */
+@property (nonatomic, strong) UIView *calloutContentView;
+
 /** Set the screen position of the layer.
 *   @param position The desired screen position.
 *   @param animated If set to `YES`, any position change is animated. */

--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -1923,6 +1923,13 @@
 
                 _currentCallout.rightAccessoryView = anAnnotation.layer.rightCalloutAccessoryView;
             }
+            
+            if (anAnnotation.layer.calloutContentView) {
+                if ([anAnnotation.layer.calloutContentView isKindOfClass:[UIControl class]])
+                    [anAnnotation.layer.calloutContentView addGestureRecognizer:[[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(tapOnCalloutAccessoryWithGestureRecognizer:)]];
+                
+                _currentCallout.contentView = anAnnotation.layer.calloutContentView;
+            }
 
             _currentCallout.delegate = self;
 


### PR DESCRIPTION
Implements setting `calloutContentView` in `RMMapLayer` in order to use it in callout view the same way as `rightAccessoryView` or `leftAccessoryView`.
As SMCalloutView's commentary on this property says about `contentView` property:
" If this is set, title/subtitle/titleView/subtitleView are all ignored. ".
