### PR TITLE
Make default behavior of the annotation position setter not animated

### DIFF
--- a/MapView/Map/RMAnnotation.m
+++ b/MapView/Map/RMAnnotation.m
@@ -130,7 +130,7 @@
 
 - (void)setPosition:(CGPoint)aPosition
 {
-    [self setPosition:aPosition animated:YES];
+    [self setPosition:aPosition animated:NO];
 }
 
 - (RMMapLayer *)layer

--- a/MapView/Map/RMShape.m
+++ b/MapView/Map/RMShape.m
@@ -44,7 +44,7 @@
 
     NSMutableArray *points;
 
-    RMMapView *mapView;
+    __weak RMMapView *mapView;
 }
 
 @synthesize scaleLineWidth;


### PR DESCRIPTION
Prevents unwanted fly-in animations when the RMMapView adds back the invisible annotations.
