### PR TITLE
Zoom to fit a number of coordinates

### DIFF
--- a/MapView/Map/RMMapView.h
+++ b/MapView/Map/RMMapView.h
@@ -251,6 +251,12 @@ typedef enum : NSUInteger {
 *   @param animated Whether to animate the zoom. */
 - (void)zoomOutToNextNativeZoomAt:(CGPoint)pivot animated:(BOOL)animated;
 
+/** Zoom the map to fit a number or coordinates with optional padding
+ *   @param coordinates An array of CLLocations to fit in the maps view.
+ *   @param paddingPercentage The percentage relative to the max distance of furthest away coordinates.
+ *   @param animated Whether to animate the zoom. */
+- (void)zoomToFitCoordinates:(NSArray *)coordinates withPaddingPercentage:(float)paddingPercentage animated:(BOOL)animated;
+
 /** Zoom the map to a given latitude and longitude bounds. 
 *   @param southWest The southwest point to zoom to. 
 *   @param northEast The northeast point to zoom to. 

--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -1207,6 +1207,32 @@
 #pragma mark -
 #pragma mark Zoom With Bounds
 
+- (void)zoomToFitCoordinates:(NSArray *)coordinates withPaddingPercentage:(float)paddingPercentage animated:(BOOL)animated
+{
+    double minLat = 90, minLon = 180, maxLat = -90, maxLon = -180;
+    
+    for (CLLocation *coord in coordinates) {
+        minLat = MIN(minLat, coord.coordinate.latitude);
+        minLon = MIN(minLon, coord.coordinate.longitude);
+        
+        maxLat = MAX(maxLat, coord.coordinate.latitude);
+        maxLon = MAX(maxLon, coord.coordinate.longitude);
+    }
+    
+    RMProjectedPoint southWestPoint = [self coordinateToProjectedPoint:CLLocationCoordinate2DMake(minLat, minLon)];
+    RMProjectedPoint northEastPoint = [self coordinateToProjectedPoint:CLLocationCoordinate2DMake(maxLat, maxLon)];
+    
+    double xAxisPadding = (northEastPoint.x - southWestPoint.x) * (paddingPercentage/100);
+    double yAxisPadding = (northEastPoint.y - southWestPoint.y) * (paddingPercentage/100);
+    
+    southWestPoint = RMProjectedPointMake(southWestPoint.x - xAxisPadding, southWestPoint.y - yAxisPadding);
+    northEastPoint = RMProjectedPointMake(northEastPoint.x + xAxisPadding, northEastPoint.y + yAxisPadding);
+    
+    [self zoomWithLatitudeLongitudeBoundsSouthWest:[self projectedPointToCoordinate:southWestPoint]
+                                         northEast:[self projectedPointToCoordinate:northEastPoint]
+                                          animated:animated];
+}
+
 - (void)zoomWithLatitudeLongitudeBoundsSouthWest:(CLLocationCoordinate2D)southWest northEast:(CLLocationCoordinate2D)northEast animated:(BOOL)animated
 {
     if (northEast.latitude == southWest.latitude && northEast.longitude == southWest.longitude) // There are no bounds, probably only one marker.


### PR DESCRIPTION
Added a function which takes an array of CLLocations, calculates the southwest and northeast points with optional padding to have any markers or annotations fit nicely.
