### PR TITLE
Fixes #422 Re-delegated the SMCalloutView’s `calloutViewClicked`

### DIFF
--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -144,6 +144,7 @@
     BOOL _delegateHasDoubleTapOnAnnotation;
     BOOL _delegateHasLongPressOnAnnotation;
     BOOL _delegateHasTapOnCalloutAccessoryControlForAnnotation;
+    BOOL _delegateHasTapOnCalloutViewForAnnotation;
     BOOL _delegateHasTapOnLabelForAnnotation;
     BOOL _delegateHasDoubleTapOnLabelForAnnotation;
     BOOL _delegateHasShouldDragAnnotation;
@@ -702,6 +703,7 @@
     _delegateHasDoubleTapOnAnnotation = [_delegate respondsToSelector:@selector(doubleTapOnAnnotation:onMap:)];
     _delegateHasLongPressOnAnnotation = [_delegate respondsToSelector:@selector(longPressOnAnnotation:onMap:)];
     _delegateHasTapOnCalloutAccessoryControlForAnnotation = [_delegate respondsToSelector:@selector(tapOnCalloutAccessoryControl:forAnnotation:onMap:)];
+    _delegateHasTapOnCalloutViewForAnnotation=[_delegate respondsToSelector:@selector(tapOnCalloutViewForAnnotation:onMap:)];
     _delegateHasTapOnLabelForAnnotation = [_delegate respondsToSelector:@selector(tapOnLabelForAnnotation:onMap:)];
     _delegateHasDoubleTapOnLabelForAnnotation = [_delegate respondsToSelector:@selector(doubleTapOnLabelForAnnotation:onMap:)];
 
@@ -2020,6 +2022,13 @@
 {
     if (_delegateHasTapOnCalloutAccessoryControlForAnnotation)
         [_delegate tapOnCalloutAccessoryControl:(UIControl *)recognizer.view forAnnotation:_currentAnnotation onMap:self];
+}
+
+-(void)calloutViewClicked:(SMCalloutView *)calloutView
+{
+    if(_delegateHasTapOnCalloutViewForAnnotation){
+        [_delegate tapOnCalloutViewForAnnotation:_currentAnnotation onMap:self];
+    }
 }
 
 - (void)doubleTapOnAnnotation:(RMAnnotation *)anAnnotation atPoint:(CGPoint)aPoint

--- a/MapView/Map/RMMapViewDelegate.h
+++ b/MapView/Map/RMMapViewDelegate.h
@@ -175,6 +175,13 @@ typedef enum : NSUInteger {
 *   @param map The map view containing the specified annotation. */
 - (void)tapOnCalloutAccessoryControl:(UIControl *)control forAnnotation:(RMAnnotation *)annotation onMap:(RMMapView *)map;
 
+/**
+ *  Tells the delefgate that the user tapped on the callout view presented by the annotation.
+ *
+ *  @param annotation The annotation whose callout view was tapped.
+ *  @param map        The map view containing the specified annotation. */
+-(void)tapOnCalloutViewForAnnotation:(RMAnnotation *)annotation onMap:(RMMapView *)map;
+
 /** Asks the delegate whether the user should be allowed to drag the layer for an annotation. 
 *   @param mapView The map view.
 *   @param annotation The annotation the user is attempting to drag. 


### PR DESCRIPTION
As per @incanus request, I've made the required changes in `RMMapViewDelegate.h` and `RMMapView.m` to fix the lack of response to tapping on callout view for selected annotation.
