### PR TITLE
annotation sorting delegate callback

### DIFF
--- a/MapView/Map/RMAnnotation.h
+++ b/MapView/Map/RMAnnotation.h
@@ -28,6 +28,9 @@
 
 #import "RMFoundation.h"
 
+#define kRMTrackingHaloAnnotationTypeName   @"RMTrackingHaloAnnotation"
+#define kRMAccuracyCircleAnnotationTypeName @"RMAccuracyCircleAnnotation"
+
 @class RMMapView, RMMapLayer, RMQuadTreeNode;
 
 /** An RMAnnotation defines a container for annotation data to be placed on a map. At a future point in time, depending on map use, a visible layer may be requested and displayed for the annotation. The layer is provided by an RMMapView's delegate when first needed for display. 

--- a/MapView/Map/RMAnnotation.h
+++ b/MapView/Map/RMAnnotation.h
@@ -79,8 +79,11 @@
 @property (nonatomic, strong) UIImage *badgeIcon;
 @property (nonatomic, assign) CGPoint anchorPoint;
 
-/** The annotation's current location on screen. Do not set this directly unless during temporary operations such as animations, but rather use the coordinate property to permanently change the annotation's location on the map. */
+/** The annotation's current location on screen relative to the map. Do not set this directly unless during temporary operations such as animations, but rather use the coordinate property to permanently change the annotation's location on the map. */
 @property (nonatomic, assign) CGPoint position;
+
+/** The annotation's absolute location on screen taking into account possible map rotation. */
+@property (nonatomic, readonly, assign) CGPoint absolutePosition;
 
 @property (nonatomic, assign) RMProjectedPoint projectedLocation; // in projected meters
 @property (nonatomic, assign) RMProjectedRect  projectedBoundingBox;

--- a/MapView/Map/RMAnnotation.m
+++ b/MapView/Map/RMAnnotation.m
@@ -133,6 +133,11 @@
     [self setPosition:aPosition animated:YES];
 }
 
+- (CGPoint)absolutePosition
+{
+    return [self.mapView.layer convertPoint:self.position fromLayer:self.layer.superlayer];
+}
+
 - (RMMapLayer *)layer
 {
     return layer;

--- a/MapView/Map/RMMapView.h
+++ b/MapView/Map/RMMapView.h
@@ -357,14 +357,8 @@ typedef enum : NSUInteger {
 /** Whether to enable clustering of map point annotations. Defaults to `NO`. */
 @property (nonatomic, assign) BOOL clusteringEnabled;
 
-/** Whether to order markers on the z-axis according to increasing y-position. Defaults to `YES`. */
-@property (nonatomic, assign) BOOL orderMarkersByYPosition;
-
 /** Whether to position cluster markers at the weighted center of the points they represent. If `YES`, position clusters in weighted fashion. If `NO`, position them on a rectangular grid. Defaults to `YES`. */
 @property (nonatomic, assign) BOOL positionClusterMarkersAtTheGravityCenter;
-
-/** Whether to order cluster markers above non-clustered markers. Defaults to `NO`. */
-@property (nonatomic, assign) BOOL orderClusterMarkersAboveOthers;
 
 @property (nonatomic, assign) CGSize clusterMarkerSize;
 @property (nonatomic, assign) CGSize clusterAreaSize;

--- a/MapView/Map/RMMapView.h
+++ b/MapView/Map/RMMapView.h
@@ -328,8 +328,8 @@ typedef enum : NSUInteger {
 /** Remove all annotations from the map. This does not remove user location annotations, if any. */
 - (void)removeAllAnnotations;
 
-/** The screen position for a given annotation. 
-*   @param annotation The annotation for which to return the current screen position.
+/** The relative map position for a given annotation. 
+*   @param annotation The annotation for which to return the current position.
 *   @return The screen position of the annotation. */
 - (CGPoint)mapPositionForAnnotation:(RMAnnotation *)annotation;
 

--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -3160,13 +3160,10 @@
 
             // Sort the rest in increasing y-position.
             //
-            CGPoint point1 = [self coordinateToPixel:annotation1.coordinate];
-            CGPoint point2 = [self coordinateToPixel:annotation2.coordinate];
-
-            if (point1.y > point2.y)
+            if (annotation1.position.y > annotation2.position.y)
                 return NSOrderedDescending;
 
-            if (point1.y < point2.y)
+            if (annotation1.position.y < annotation2.position.y)
                 return NSOrderedAscending;
 
             return NSOrderedSame;

--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -66,9 +66,6 @@
 #define kDefaultMaximumZoomLevel 25.0
 #define kDefaultInitialZoomLevel 11.0
 
-#define kRMTrackingHaloAnnotationTypeName   @"RMTrackingHaloAnnotation"
-#define kRMAccuracyCircleAnnotationTypeName @"RMAccuracyCircleAnnotation"
-
 #pragma mark --- end constants ----
 
 @interface RMMapView (PrivateMethods) <UIScrollViewDelegate,

--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -3112,10 +3112,6 @@
     }
     else
     {
-        // Default to MapKit behavior, which is sorting back-to-front based on
-        // screen top-to-bottom ordering, with user location annotations at the
-        // bottom.
-        //
         // First, don't bother sorting user location annotations since we
         // statically apply their layering.
         //
@@ -3158,7 +3154,7 @@
             return NSOrderedSame;
         }];
 
-        // Manually apply layering values to the user location annotations.
+        // Manually place user location annotations below all others.
         //
         _accuracyCircleAnnotation.layer.zPosition = -MAXFLOAT;
         _trackingHaloAnnotation.layer.zPosition   = -MAXFLOAT + 1;

--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -705,7 +705,7 @@
     _delegateHasDidChangeDragState = [_delegate respondsToSelector:@selector(mapView:annotation:didChangeDragState:fromOldState:)];
 
     _delegateHasLayerForAnnotation = [_delegate respondsToSelector:@selector(mapView:layerForAnnotation:)];
-    _delegateHasAnnotationSorting = [_delegate respondsToSelector:@selector(mapView:sortingForAnnotation:comparedToAnnotation:)];
+    _delegateHasAnnotationSorting = [_delegate respondsToSelector:@selector(annotationSortingComparatorForMapView:)];
     _delegateHasWillHideLayerForAnnotation = [_delegate respondsToSelector:@selector(mapView:willHideLayerForAnnotation:)];
     _delegateHasDidHideLayerForAnnotation = [_delegate respondsToSelector:@selector(mapView:didHideLayerForAnnotation:)];
 

--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -3160,10 +3160,10 @@
 
             // Sort the rest in increasing y-position.
             //
-            if (annotation1.position.y > annotation2.position.y)
+            if (annotation1.absolutePosition.y > annotation2.absolutePosition.y)
                 return NSOrderedDescending;
 
-            if (annotation1.position.y < annotation2.position.y)
+            if (annotation1.absolutePosition.y < annotation2.absolutePosition.y)
                 return NSOrderedAscending;
 
             return NSOrderedSame;

--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -3127,10 +3127,10 @@
             // Sort clusters below non-clusters.
             //
             if (   annotation1.isClusterAnnotation && ! annotation2.isClusterAnnotation)
-                return NSOrderedAscending;
+                return NSOrderedDescending;
 
             if ( ! annotation1.isClusterAnnotation &&   annotation2.isClusterAnnotation)
-                return NSOrderedDescending;
+                return NSOrderedAscending;
 
             // Sort markers above shapes.
             //

--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -3102,16 +3102,13 @@
 {
     NSMutableArray *sortedAnnotations = [NSMutableArray arrayWithArray:[_visibleAnnotations allObjects]];
 
-    if (_delegateHasAnnotationSorting)
-    {
-        NSComparator comparator;
+    NSComparator comparator;
 
-        if ((comparator = [_delegate annotationSortingComparatorForMapView:self]))
-        {
-            // Sort using the custom comparator.
-            //
-            [sortedAnnotations sortUsingComparator:comparator];
-        }
+    if (_delegateHasAnnotationSorting && (comparator = [_delegate annotationSortingComparatorForMapView:self]))
+    {
+        // Sort using the custom comparator.
+        //
+        [sortedAnnotations sortUsingComparator:comparator];
     }
     else
     {

--- a/MapView/Map/RMMapViewDelegate.h
+++ b/MapView/Map/RMMapViewDelegate.h
@@ -64,6 +64,21 @@ typedef enum : NSUInteger {
 *   @return The annotation layer to display for the specified annotation or `nil` if you do not want to display a layer. */
 - (RMMapLayer *)mapView:(RMMapView *)mapView layerForAnnotation:(RMAnnotation *)annotation;
 
+/** Returns a block used for determining the sort order of annotation layers. The block will be called repeatedly during map change events to ensure annotation layers stay sorted in the desired order.
+*
+*   If you do not implement this method, a default sort order will be used. First, user location annotation layers will be shown underneath all other annotation layers. Then, any cluster annotation layers are placed above that, then shape annotation layers, then finally marker annotation layers. Marker annotation layers closer to the bottom of the screen will be sorted above those closer to the top of the screen to provide a natural-looking sort order.
+* 
+*   In all cases, any currently selected annotation (and its possible callout) are shown above all other annotations.
+*
+*   Your implementation of this method should be as lightweight as possible to avoid affecting map renderering performance. 
+*
+*   @see [RMAnnotation isClusterAnnotation]
+*   @see [RMAnnotation isUserLocationAnnotation]
+*
+*   @param mapView The map view whose annotations need sorting. 
+*   @return A comparison block to use in order to sort the annotations. */
+- (NSComparator)annotationSortingComparatorForMapView:(RMMapView *)mapView;
+
 /** Tells the delegate that the visible layer for an annotation is about to be hidden from view due to scrolling or zooming the map.
 *   @param mapView The map view whose annotation alyer will be hidden.
 *   @param annotation The annotation whose layer will be hidden. */

--- a/MapView/Map/RMMapViewDelegate.h
+++ b/MapView/Map/RMMapViewDelegate.h
@@ -66,7 +66,7 @@ typedef enum : NSUInteger {
 
 /** Returns a block used for determining the sort order of annotation layers. The block will be called repeatedly during map change events to ensure annotation layers stay sorted in the desired order.
 *
-*   If you do not implement this method, a default sort order will be used. First, user location annotation layers will be shown underneath all other annotation layers. Then, any cluster annotation layers are placed above that, then shape annotation layers, then finally marker annotation layers. Marker annotation layers closer to the bottom of the screen will be sorted above those closer to the top of the screen to provide a natural-looking sort order.
+*   If you do not implement this method, a default sort order will be used. First, user location annotation layers will be shown underneath all other annotation layers. Then, any shape annotation layers are placed above that, then marker annotation layers, and finally, cluster annotation layers. Marker annotation layers closer to the bottom of the screen will be sorted above those closer to the top of the screen to provide a natural-looking sort order.
 * 
 *   In all cases, any currently selected annotation (and its possible callout) are shown above all other annotations.
 *

--- a/MapView/Map/RMMapViewDelegate.h
+++ b/MapView/Map/RMMapViewDelegate.h
@@ -64,16 +64,28 @@ typedef enum : NSUInteger {
 *   @return The annotation layer to display for the specified annotation or `nil` if you do not want to display a layer. */
 - (RMMapLayer *)mapView:(RMMapView *)mapView layerForAnnotation:(RMAnnotation *)annotation;
 
-/** Returns a block used for determining the sort order of annotation layers. The block will be called repeatedly during map change events to ensure annotation layers stay sorted in the desired order.
+/** Returns a block used for determining the display sort order of annotation layers. The block will be called repeatedly during map change events to ensure annotation layers stay sorted in the desired order.
 *
-*   If you do not implement this method, a default sort order will be used. First, user location annotation layers will be shown underneath all other annotation layers. Then, any shape annotation layers are placed above that, then marker annotation layers, and finally, cluster annotation layers. Marker annotation layers closer to the bottom of the screen will be sorted above those closer to the top of the screen to provide a natural-looking sort order.
-* 
-*   In all cases, any currently selected annotation (and its possible callout) are shown above all other annotations.
+*   If you do not implement this method, a default sort order will be used as follows: 
+*
+*   1. User location annotations are below all others. These can be distinguished by `annotation.isUserLocationAnnotation = YES`.
+*
+*   1. Amongst user location annotations, the accuracy circle is below the tracking halo, which is below the user location. These can be distinguished by `annotation.annotationType = kRMTrackingHaloAnnotationTypeName`, `annotation.annotationType = kRMAccuracyCircleAnnotationTypeName`, and checking annotation object type against RMUserLocation.
+*
+*   1. Cluster annotations are above non-cluster annotations. These can be distinguished by `annotation.isClusterAnnotation = YES`. 
+*
+*   1. Markers are above shapes. These can be distinguished by checking annotation object type against RMMarker. 
+*
+*   1. The remaining annotations are sorted with those closer to the bottom of the view above those closer to the top of the view. This includes during user tracking mode map rotation events, when markers always remain upright and their relative layer positions change.
+*
+*   In all cases, any currently selected annotation (and its callout, if visible) are shown above all other annotations. When deselected, the desired sort order is reapplied.
 *
 *   Your implementation of this method should be as lightweight as possible to avoid affecting map renderering performance. 
 *
-*   @see [RMAnnotation isClusterAnnotation]
 *   @see [RMAnnotation isUserLocationAnnotation]
+*   @see [RMAnnotation annotationType]
+*   @see [RMAnnotation isClusterAnnotation]
+*   @see [RMMapView coordinateToPixel:]
 *
 *   @param mapView The map view whose annotations need sorting. 
 *   @return A comparison block to use in order to sort the annotations. */

--- a/MapView/Map/RMUserLocation.m
+++ b/MapView/Map/RMUserLocation.m
@@ -76,8 +76,6 @@
             else
                 [self updateTintColor];
         }
-
-        super.layer.zPosition = -MAXFLOAT + 2;
     }
 
     return super.layer;


### PR DESCRIPTION
First cut of solution to #160 (and indirectly #164) by allowing a map view delegate to provide an `NSComparator` for sorting annotation layers. 
