### PR TITLE
perf improvement to RMDatabaseCache when counting existing tiles

### DIFF
--- a/MapView/Map/RMDatabaseCache.m
+++ b/MapView/Map/RMDatabaseCache.m
@@ -308,7 +308,7 @@
 
     [_queue inDatabase:^(FMDatabase *db)
      {
-         FMResultSet *results = [db executeQuery:@"SELECT COUNT(tile_hash) FROM ZCACHE"];
+         FMResultSet *results = [db executeQuery:@"SELECT COUNT(*) FROM ZCACHE"];
 
          if ([results next])
              count = [results intForColumnIndex:0];


### PR DESCRIPTION
The existing code in RMDatabaseCache specifies a column name. According to sqlite specs, this means sqlite will perform null-checks for values in this column and exclude them from the count.

tile_hash should never be null, so we can skip this null-check behaviour by specifying a wildcard.

On my sample database cache of 9000 tiles, time to tile count went from about 5-6 seconds down to almost instantaneous.
