### PR TITLE
Added db cache max file size configuration option

### DIFF
--- a/MapView/Map/RMDatabaseCache.h
+++ b/MapView/Map/RMDatabaseCache.h
@@ -65,6 +65,13 @@
 /** The capacity, in number of tiles, that the database cache can hold. */
 @property (nonatomic, readonly, assign) NSUInteger capacity;
 
+/** Set the maximum bytes allowed in the database.
+ *   @param theCapacityBytes The number of bytes to allow to accumulate in the database before purging begins. */
+- (void)setCapacityBytes:(NSUInteger)theCapacityBytes;
+
+/** The max file size in bytes, that the database cache can hold. */
+@property (nonatomic, readonly, assign) NSUInteger capacityBytes;
+
 /** Set the minimum number of tiles to purge when clearing space in the cache.
 *   @param thePurgeMinimum The number of tiles to delete at the time the cache is purged. */
 - (void)setMinimalPurge:(NSUInteger)thePurgeMinimum;

--- a/MapView/Map/RMTileCache.m
+++ b/MapView/Map/RMTileCache.m
@@ -487,11 +487,13 @@ static NSMutableDictionary *predicateValues = nil;
     RMCachePurgeStrategy strategy = RMCachePurgeStrategyFIFO;
 
     NSUInteger capacity = 1000;
+    NSUInteger bytes = 32 * 1024 * 1042;
     NSUInteger minimalPurge = capacity / 10;
 
     // Defaults
 
     NSNumber *capacityNumber = [cfg objectForKey:@"capacity"];
+    NSNumber *capacityMb = [cfg objectForKey:@"capacityMb"];
 
     if ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad && [cfg objectForKey:@"capacity-ipad"])
     {
@@ -549,6 +551,19 @@ static NSMutableDictionary *predicateValues = nil;
             RMLog(@"illegal value for capacity: %ld", (long)value);
         }
     }
+    
+    if (capacityMb != nil) {
+        NSInteger value = [capacityMb integerValue];
+        
+        if (value >= 0)
+        {
+            bytes = value * 1024 * 1024;
+        }
+        else
+        {
+            RMLog(@"illegal value for bytes: %ld", (long)value);
+        }
+    }
 
     if (strategyStr != nil)
     {
@@ -580,6 +595,7 @@ static NSMutableDictionary *predicateValues = nil;
 
     RMDatabaseCache *dbCache = [[RMDatabaseCache alloc] initUsingCacheDir:useCacheDir];
     [dbCache setCapacity:capacity];
+    [dbCache setCapacityBytes:bytes];
     [dbCache setPurgeStrategy:strategy];
     [dbCache setMinimalPurge:minimalPurge];
     [dbCache setExpiryPeriod:_expiryPeriod];


### PR DESCRIPTION
Constrains the file size if you have different tile weights per layer etc and number of cached tiles isn't enough. Default capacity is 32Mb.
