### PR TITLE
Fixed offset calculation

### DIFF
--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -2006,9 +2006,28 @@
 
     contentOffset.x -= offset.width;
     contentOffset.y -= offset.height;
-
-    if (RMPostVersion7)
-        contentOffset.y -= [[[self viewController] topLayoutGuide] length];
+    
+    if (RMPostVersion7) {
+        CGRect calloutRect = [calloutView.layer convertRect:calloutView.layer.frame fromLayer:self.layer.superlayer];
+        calloutRect.origin.x *= -1;
+        calloutRect.origin.y *= -1;
+        calloutRect.origin.y -= calloutRect.size.height;
+        
+        CGRect annotationRect = CGRectMake(calloutRect.origin.x, calloutRect.origin.y + calloutRect.size.height, calloutView.layer.superlayer.frame.size.width, calloutView.layer.superlayer.frame.size.height);
+        
+        CGFloat calloutTop = calloutRect.origin.y;
+        CGFloat topLayoutGuide = [[[self viewController] topLayoutGuide] length];
+        CGFloat annotationBottom = annotationRect.origin.y + annotationRect.size.height;
+        CGFloat bottomLayoutGuide = self.frame.size.height - [[[self viewController] bottomLayoutGuide] length];
+        
+        if (calloutTop < topLayoutGuide) {
+            contentOffset.y -= (topLayoutGuide - calloutTop) + 10;
+        }
+ 
+        if (annotationBottom > bottomLayoutGuide) {
+            contentOffset.y += fabs(annotationBottom - bottomLayoutGuide) + 10;
+        }
+    }
 
     [_mapScrollView setContentOffset:contentOffset animated:YES];
 

--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -1960,8 +1960,8 @@
                 constrainLayer = [CALayer layer];
                 constrainLayer.frame = self.layer.frame;
                 
-                CGFloat topLayoutGuide = [[[self viewController] topLayoutGuide] length];
-                CGFloat bottomLayoutGuide = [[[self viewController] bottomLayoutGuide] length];
+                CGFloat topLayoutGuide = [[self.viewController.parentViewController topLayoutGuide] length] + 44;
+                CGFloat bottomLayoutGuide = [[self.viewController.parentViewController bottomLayoutGuide] length];
                 
                 CGRect newFrame = CGRectMake(self.layer.frame.origin.x,
                                              self.layer.frame.origin.y + topLayoutGuide,

--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -1954,10 +1954,33 @@
 
             _currentCallout.permittedArrowDirection = SMCalloutArrowDirectionDown;
 
+            CALayer *constrainLayer = self.layer;
+            if (RMPostVersion7)
+            {
+                constrainLayer = [CALayer layer];
+                constrainLayer.frame = self.layer.frame;
+                
+                CGFloat topLayoutGuide = [[[self viewController] topLayoutGuide] length];
+                CGFloat bottomLayoutGuide = [[[self viewController] bottomLayoutGuide] length];
+                
+                CGRect newFrame = CGRectMake(self.layer.frame.origin.x,
+                                             self.layer.frame.origin.y + topLayoutGuide,
+                                             self.layer.frame.size.width,
+                                             self.layer.frame.size.height - (bottomLayoutGuide + topLayoutGuide));
+                constrainLayer.frame = newFrame;
+                
+                [self.layer addSublayer:constrainLayer];
+            }
+            
             [_currentCallout presentCalloutFromRect:anAnnotation.layer.bounds
                                             inLayer:anAnnotation.layer
-                                 constrainedToLayer:self.layer
+                                 constrainedToLayer:constrainLayer
                                            animated:animated];
+            
+            if (RMPostVersion7)
+            {
+                [constrainLayer removeFromSuperlayer];
+            }
         }
 
         [self correctPositionOfAllAnnotations];
@@ -2006,28 +2029,6 @@
 
     contentOffset.x -= offset.width;
     contentOffset.y -= offset.height;
-    
-    if (RMPostVersion7) {
-        CGRect calloutRect = [calloutView.layer convertRect:calloutView.layer.frame fromLayer:self.layer.superlayer];
-        calloutRect.origin.x *= -1;
-        calloutRect.origin.y *= -1;
-        calloutRect.origin.y -= calloutRect.size.height;
-        
-        CGRect annotationRect = CGRectMake(calloutRect.origin.x, calloutRect.origin.y + calloutRect.size.height, calloutView.layer.superlayer.frame.size.width, calloutView.layer.superlayer.frame.size.height);
-        
-        CGFloat calloutTop = calloutRect.origin.y;
-        CGFloat topLayoutGuide = [[[self viewController] topLayoutGuide] length];
-        CGFloat annotationBottom = annotationRect.origin.y + annotationRect.size.height;
-        CGFloat bottomLayoutGuide = self.frame.size.height - [[[self viewController] bottomLayoutGuide] length];
-        
-        if (calloutTop < topLayoutGuide) {
-            contentOffset.y -= (topLayoutGuide - calloutTop) + 10;
-        }
- 
-        if (annotationBottom > bottomLayoutGuide) {
-            contentOffset.y += fabs(annotationBottom - bottomLayoutGuide) + 10;
-        }
-    }
 
     [_mapScrollView setContentOffset:contentOffset animated:YES];
 


### PR DESCRIPTION
Your offset calculation for callouts is flawed. You should only adjust for the topLayoutGuide if necessary and adjustment for bottomLayoutGuide was missing entirely.

Without this fix on iOS 7+, when position is adjusted it will always be adjusted downwards and never adjusted upwards.
