### PR TITLE
Restore userLocation hidden state after hit testing

### DIFF
--- a/MapView/Map/RMMapOverlayView.m
+++ b/MapView/Map/RMMapOverlayView.m
@@ -96,13 +96,14 @@
     for (RMAnnotation *annotation in disabledVisibleAnnotations)
         annotation.layer.hidden = YES;
 
+    BOOL userLocationWasHidden = mapView.userLocation.layer.hidden;
     if (mapView.userLocation.enabled && mapView.userTrackingMode == RMUserTrackingModeFollowWithHeading)
         mapView.userLocation.layer.hidden = NO;
 
     CALayer *hit = [self.layer hitTest:point];
 
     if (mapView.userLocation.enabled && mapView.userTrackingMode == RMUserTrackingModeFollowWithHeading)
-        mapView.userLocation.layer.hidden = YES;
+        mapView.userLocation.layer.hidden = userLocationWasHidden;
 
     for (RMAnnotation *annotation in disabledVisibleAnnotations)
         annotation.layer.hidden = NO;


### PR DESCRIPTION
Without this fix, the blue userLocation tracking dot disappears if you tap it in heading tracking mode and returns once you get a new fix.
