### PR TITLE
Check status before stacking user location

### DIFF
--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -3326,7 +3326,12 @@
 
         _locationManager.headingFilter = 5.0;
         _locationManager.delegate = self;
-        [_locationManager startUpdatingLocation];
+        
+        CLAuthorizationStatus status = [CLLocationManager authorizationStatus];
+        if (status != kCLAuthorizationStatusDenied && status != kCLAuthorizationStatusRestricted)
+        {
+            [_locationManager startUpdatingLocation];
+        }
     }
     else
     {


### PR DESCRIPTION
If you start tracking the user location with a denied or restricted status on iOS 8, the system alert asking you to go to settings will appear, and then MapBox code will call stopUpdatingUserLocation and the alert will go away a moment later. It looks very annoying and according to the Core Location documentation you should not attempt to use the framework if the status is denied or restricted, so i added this check.
