### PR TITLE
lock prior to count+purge to prevent maxing out operation queue

### DIFF
--- a/MapView/Map/RMDatabaseCache.m
+++ b/MapView/Map/RMDatabaseCache.m
@@ -251,6 +251,8 @@
 
     if (_capacity != 0)
     {
+        [_writeQueueLock lock];
+
         NSUInteger tilesInDb = [self count];
 
         if (_capacity <= tilesInDb && _expiryPeriod == 0)
@@ -262,8 +264,6 @@
         // insert operations pending. This prevents some memory issues.
 
         BOOL skipThisTile = NO;
-
-        [_writeQueueLock lock];
 
         if ([_writeQueue operationCount] > kWriteQueueLimit)
             skipThisTile = YES;


### PR DESCRIPTION
..which would happen if several threads enter in rapid succession and
all determine the capacity is exceeded, waiting for a purge lock. This
is especially visible if the tiles are loaded from a slow endpoint.
