### PR TITLE
allow annotations (besides the dragged annotation) to be updated while dragging

### DIFF
--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -3007,7 +3007,9 @@
                 [_visibleAnnotations addObject:annotation];
             }
 
-            [self correctScreenPosition:annotation animated:animated];
+            if (!_draggedAnnotation || ![annotation isEqual:_draggedAnnotation]) {
+                [self correctScreenPosition:annotation animated:animated];
+            }
 
             [previousVisibleAnnotations removeObject:annotation];
         }


### PR DESCRIPTION
Just a quick edit so that an annotation that's being dragged can update other annotations without canceling its own drag.
