### PR TITLE
Use localized NSLocationWhenInUseUsageDescription key for assert

### DIFF
--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -3321,7 +3321,7 @@
         //
         if ([CLLocationManager instancesRespondToSelector:@selector(requestWhenInUseAuthorization)])
         {
-            NSAssert([[[NSBundle mainBundle] infoDictionary] valueForKey:@"NSLocationWhenInUseUsageDescription"], @"For iOS 8 and above, your app must have a value for NSLocationWhenInUseUsageDescription in its Info.plist");
+            NSAssert([[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationWhenInUseUsageDescription"], @"For iOS 8 and above, your app must have a value for NSLocationWhenInUseUsageDescription in its Info.plist");
             [_locationManager requestWhenInUseAuthorization];
         }
 #endif


### PR DESCRIPTION
From Apple’s Bundle Programming Guide:

> The `NSBundle` class provides the `objectForInfoDictionaryKey:` and `infoDictionary` methods for retrieving information from the `Info.plist` file. The `objectForInfoDictionaryKey:` method returns the localized value for a key and is the preferred method to call. The `infoDictionary` method returns an `NSDictionary` with all of the keys from the property list; however, it does not return any localized values for these keys. For more information, see the _NSBundle Class Reference_.

This was an issue I ran into first hand.
##### Tests Run
1. Have localized `NSLocationWhenInUseUsageDescription` only (in `InfoPlist.strings`)
2. Have unlocalized `NSLocationWhenInUseUsageDescription` only (in standard Info.plist)
3. Have both
4. Missing both

Expected behavior in all cases; 1-3 do not assert, 4 does assert.
Before this PR, 1 unexpectedly asserts.

Closes #548.
