### PR TITLE
Fix bug that prevents tile downloads for offline use

### DIFF
--- a/MapView/Map/RMTileCacheDownloadOperation.m
+++ b/MapView/Map/RMTileCacheDownloadOperation.m
@@ -41,7 +41,7 @@
     if (!(self = [super init]))
         return nil;
 
-    NSAssert([_source isKindOfClass:[RMAbstractWebMapSource class]], @"only web-based tile sources are supported for downloading");
+    NSAssert([source isKindOfClass:[RMAbstractWebMapSource class]], @"only web-based tile sources are supported for downloading");
 
     _tile   = tile;
     _source = source;


### PR DESCRIPTION
I'm happy to provide a test case for this - I saw it while upgrading my MapRhino app from version 1.4.0 to version 1.6.0 using CocoaPods.
