### PR TITLE
Fix sync load blocker with initWithCoder

### DIFF
--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -639,7 +639,12 @@
         // needs a scroll view frame in order to calculate _metersPerPixel.
         // See https://github.com/mapbox/mapbox-ios-sdk/issues/270
         //
-        [self performInitializationWithTilesource:[RMMapboxSource new]
+        RMMapboxSource * source = nil;
+        // Do not allocate a new tile source as it loads with a synchronous call
+        if (![_earlyTileSources count]){
+            source = [RMMapboxSource new];
+        }
+        [self performInitializationWithTilesource:source
                                  centerCoordinate:CLLocationCoordinate2DMake(kDefaultInitialLatitude, kDefaultInitialLongitude)
                                         zoomLevel:kDefaultInitialZoomLevel
                                      maxZoomLevel:kDefaultMaximumZoomLevel


### PR DESCRIPTION
Instantiating [RMMapboxSouce new] was creating a synchronous call even with a early tile source set which was blocking the whole interface
