### PR TITLE
#578: Unrequire access token for large tiles

### DIFF
--- a/MapView/Map/RMMapboxSource.m
+++ b/MapView/Map/RMMapboxSource.m
@@ -369,7 +369,7 @@
 
 + (BOOL)isUsingLargeTiles
 {
-    return ([[RMConfiguration sharedInstance] accessToken] && [[UIScreen mainScreen] scale] > 1.0);
+    return ([[UIScreen mainScreen] scale] > 1.0);
 }
 
 - (NSString *)uniqueTilecacheKey


### PR DESCRIPTION
Fixes #578 by removing an unnecessary access token check.
