### PR TITLE
Fix [RMMarker initWithMapboxMarkerImage] crash in case of blank string

### DIFF
--- a/MapView/Map/RMMarker.m
+++ b/MapView/Map/RMMarker.m
@@ -142,6 +142,15 @@
 {
     BOOL useRetina = ([[UIScreen mainScreen] scale] > 1.0);
 
+    if ( ! symbolName.length)
+        symbolName = nil;
+
+    if ( ! colorHex.length)
+        colorHex = nil;
+
+    if ( ! sizeString.length)
+        sizeString = nil;
+
     NSURL *imageURL = [NSURL URLWithString:[NSString stringWithFormat:@"https://api.tiles.mapbox.com/v4/marker/pin-%@%@%@%@.png%@",
                                                (sizeString ? [sizeString substringToIndex:1] : @"m"),
                                                (symbolName ? [@"-" stringByAppendingString:symbolName] : @""),


### PR DESCRIPTION
There is a possibility of the Mapbox online editor adding marker styling attributes without values, which can result in a crash:

``` objective-c
2015-03-13 21:25:17.950 Picks[33638:1475229] Added the tilesource 'Undefined Styles' to the container
2015-03-13 21:25:19.462 Picks[33638:1475229] *** Terminating app due to uncaught exception 'NSRangeException', reason: '*** -[__NSCFConstantString substringToIndex:]: Index 1 out of bounds; string length 0'
*** First throw call stack:
(
    0   CoreFoundation                      0x000000010c84ba75 __exceptionPreprocess + 165
    1   libobjc.A.dylib                     0x000000010c4e4bb7 objc_exception_throw + 45
    2   CoreFoundation                      0x000000010c84b9ad +[NSException raise:format:] + 205
    3   Foundation                          0x000000010a9e1e65 -[NSString substringToIndex:] + 118
    4   Mapbox_iOS_SDK                      0x000000010a5ee355 -[RMMarker initWithMapboxMarkerImage:tintColorHex:sizeString:] + 325
    5   Picks                               0x000000010a469867 -[MBWPViewController mapView:layerForAnnotation:] + 455
    6   Mapbox_iOS_SDK                      0x000000010a5dd406 -[RMMapView correctPositionOfAllAnnotationsIncludingInvisibles:animated:] + 2630
    7   Mapbox_iOS_SDK                      0x000000010a5de835 -[RMMapView correctPositionOfAllAnnotations] + 53
    8   Mapbox_iOS_SDK                      0x000000010a5d0d44 -[RMMapView scrollViewDidEndZooming:withView:atScale:] + 340
    9   UIKit                               0x000000010b17b346 -[UIScrollView _zoomAnimationDidStop] + 294
    10  UIKit                               0x000000010b1476ca -[UIViewAnimationState sendDelegateAnimationDidStop:finished:] + 209
    11  UIKit                               0x000000010b147a00 -[UIViewAnimationState animationDidStop:finished:] + 76
    12  QuartzCore                          0x000000010af7465e _ZN2CA5Layer23run_animation_callbacksEPv + 308
    13  libdispatch.dylib                   0x000000010cd48614 _dispatch_client_callout + 8
    14  libdispatch.dylib                   0x000000010cd30a1c _dispatch_main_queue_callback_4CF + 1664
    15  CoreFoundation                      0x000000010c7b3749 __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__ + 9
    16  CoreFoundation                      0x000000010c77662b __CFRunLoopRun + 2043
    17  CoreFoundation                      0x000000010c775bc6 CFRunLoopRunSpecific + 470
    18  GraphicsServices                    0x000000010f1f8a58 GSEventRunModal + 161
    19  UIKit                               0x000000010b0ed580 UIApplicationMain + 1282
    20  Picks                               0x000000010a4679f3 main + 115
    21  libdyld.dylib                       0x000000010cd7d145 start + 1
)
libc++abi.dylib: terminating with uncaught exception of type NSException
```

That happens with [`friedbunny.lec17m0c`](https://api.tiles.mapbox.com/v4/friedbunny.lec17m0c/page.html?access_token=pk.eyJ1IjoianVzdGluIiwiYSI6IlpDbUJLSUEifQ.4mG8vhelFMju6HpIY-Hi5A#14/45.5392/-122.6830), a test map with imported GeoJSON that didn't get styled correctly (but still shows up on the editor map). Here's what one unstyled marker looks like [coming out of the Mapbox API](https://a.tiles.mapbox.com/v4/friedbunny.lec17m0c/features.json?access_token=pk.eyJ1IjoianVzdGluIiwiYSI6IlpDbUJLSUEifQ.4mG8vhelFMju6HpIY-Hi5A):

``` json
{  
  "geometry":{  
    "coordinates":[  
      -122.671966,
      45.501534
    ],
    "type":"Point"
  },
  "id":"ci76izbfs0099hbm4i4oe0zqj",
  "properties":{  
    "description":"",
    "id":"marker-i76hpkpi6",
    "marker-color":"",
    "marker-size":"",
    "marker-symbol":"",
    "title":""
  }
}
```

If the developer isn't careful (or isn't aware the marker is unstyled), those properties could get passed as blank strings into `RMMarker`. If the `sizeString` is blank, it crashes. Blank `symbolName` or `colorHex` result in no marker being drawn and no error.

By converting blank strings to `nil`, this lets the defaults in the code just below work.

Originally reported in: mapbox/weekend-picks-template-ios/issues/5
