### PR TITLE
Fix issue 589 - map screenshot tile resolution incorrect on retina devices

### DIFF
--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -2634,10 +2634,11 @@
 
 - (float)adjustedZoomForRetinaDisplay
 {
-    if (!self.adjustTilesForRetinaDisplay && _screenScale > 1.0 && ! [RMMapboxSource isUsingLargeTiles])
-        return [self zoom] + 1.0;
+    if (!self.adjustTilesForRetinaDisplay && self.screenScale > 1.0 && [RMMapboxSource isUsingLargeTiles]) {
+        return fminf(self.tileSourcesMaxZoom, self.zoom + 1.0);
+    }
 
-    return [self zoom];
+    return self.zoom;
 }
 
 - (RMProjection *)projection


### PR DESCRIPTION
Fix RMMapView adjustedZoomForRetinaDisplay calculation, which was causing map snapshot to render tiles at incorrect zoom level.

Also fixes issue where the snapshot would try to render zoom levels outside of the min zoom level for the map's current tile sources, resulting in a blank snapshot image.
