### PR TITLE
Better Clustering

### DIFF
--- a/MapView/Map/RMAnnotation.h
+++ b/MapView/Map/RMAnnotation.h
@@ -106,6 +106,9 @@
 /** Whether the annotation should be clustered when map view clustering is enabled. Defaults to `YES`. */
 @property (nonatomic, assign) BOOL clusteringEnabled;
 
+/** Only annotations with the same clusteringIdentifier may be clustered together. */
+@property (nonatomic, strong) id clusteringIdentifier;
+
 /** Whether an annotation is an automatically-managed cluster annotation. */
 @property (nonatomic, readonly, assign) BOOL isClusterAnnotation;
 

--- a/MapView/Map/RMAnnotation.m
+++ b/MapView/Map/RMAnnotation.m
@@ -60,7 +60,6 @@
 @synthesize position;
 @synthesize quadTreeNode;
 @synthesize isClusterAnnotation=_isClusterAnnotation;
-@synthesize clusteredAnnotations;
 @synthesize isUserLocationAnnotation;
 
 + (instancetype)annotationWithMapView:(RMMapView *)aMapView coordinate:(CLLocationCoordinate2D)aCoordinate andTitle:(NSString *)aTitle
@@ -194,7 +193,7 @@
 
 - (NSArray *)clusteredAnnotations
 {
-    return (self.isClusterAnnotation ? ((RMQuadTreeNode *)self.userInfo).clusteredAnnotations : nil);
+    return (self.isClusterAnnotation ? [((RMQuadTreeNode *)self.userInfo) clusteredAnnotationsForClusterIdentifier:self.clusteringIdentifier] : nil);
 }
 
 - (void)setIsUserLocationAnnotation:(BOOL)flag

--- a/MapView/Map/RMQuadTree.h
+++ b/MapView/Map/RMQuadTree.h
@@ -54,8 +54,8 @@ typedef enum : short {
 @property (nonatomic, readonly) RMQuadTreeNode *southWest;
 @property (nonatomic, readonly) RMQuadTreeNode *southEast;
 
-@property (nonatomic, weak, readonly) RMAnnotation *clusterAnnotation;
-@property (nonatomic, weak, readonly) NSArray *clusteredAnnotations;
+-(RMAnnotation *)clusterAnnotationForClusterIdentifier:(id)clusterIdentifier;
+-(NSArray *)clusteredAnnotationsForClusterIdentifier:(id)clusterIdentifier;
 
 // Operations on this node and all subnodes
 @property (nonatomic, weak, readonly) NSArray *enclosedAnnotations;


### PR DESCRIPTION
I have read the discussion in #439 and this is my attempt to solve it using using the single quad tree.

It is now possible to set a `clusteringIdentifier' on`RMAnnotation`. 
The annotations that should be clustered divided into separate arrays for each`clusteringIdentifier` and then the clustering is performed for each of those arrays. 
