### PR TITLE
Better support for NSLocationAlwaysUsageDescription in info.plist

### DIFF
--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -3317,11 +3317,12 @@
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 80000
         // enable iOS 8+ location authorization API
         //
-        if ([CLLocationManager instancesRespondToSelector:@selector(requestWhenInUseAuthorization)])
-        {
-            BOOL hasLocationDescription = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationWhenInUseUsageDescription"] ||
-                [[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationAlwaysUsageDescription"];
-            NSAssert(hasLocationDescription, @"For iOS 8 and above, your app must have a value for NSLocationWhenInUseUsageDescription or NSLocationAlwaysUsageDescription in its Info.plist");
+        NSString *alwaysDescription = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationAlwaysUsageDescription"];
+        if (alwaysDescription && [CLLocationManager instancesRespondToSelector:@selector(requestAlwaysAuthorization)]) {
+            [_locationManager requestAlwaysAuthorization];
+        } else if ([CLLocationManager instancesRespondToSelector:@selector(requestWhenInUseAuthorization)]) {
+            NSString *whenInUseDescription = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationWhenInUseUsageDescription"];
+            NSAssert(whenInUseDescription, @"For iOS 8 and above, your app must have a value for NSLocationWhenInUseUsageDescription or NSLocationAlwaysUsageDescription in its Info.plist");
             [_locationManager requestWhenInUseAuthorization];
         }
 #endif


### PR DESCRIPTION
If project uses NSLocationAlwaysUsageDescription, use appropriate access request.

If a project is set up for `NSLocationAlwaysUsageDescription` and not `NSLocationWhenInUseUsageDescription`, it would be expected that `RMMapView` asks for `requestAlwaysAuthorization` and not `requestWhenInUseAuthorization`. 
Since iOS doesn't allow for a second request this is really critical i.e. if `RMMapView` has asked for `requestWhenInUseAuthorization`, the app can ask for `requestAlwaysAuthorization` later, but a prompt is _not_ shown to the user.
