### PR TITLE
Include all header files in podspec

### DIFF
--- a/Mapbox-iOS-SDK.podspec
+++ b/Mapbox-iOS-SDK.podspec
@@ -27,32 +27,7 @@ Pod::Spec.new do |m|
   m.prefix_header_file = 'MapView/MapView_Prefix.pch'
 
   m.public_header_files = [
-    'MapView/Map/Mapbox.h',
-    'MapView/Map/RMAnnotation.h',
-    'MapView/Map/RMCacheObject.h',
-    'MapView/Map/RMCircle.h',
-    'MapView/Map/RMCircleAnnotation.h',
-    'MapView/Map/RMCompositeSource.h',
-    'MapView/Map/RMConfiguration.h',
-    'MapView/Map/RMCoordinateGridSource.h',
-    'MapView/Map/RMDatabaseCache.h',
-    'MapView/Map/RMGreatCircleAnnotation.h',
-    'MapView/Map/RMInteractiveSource.h',
-    'MapView/Map/RMMBTilesSource.h',
-    'MapView/Map/RMMapboxSource.h',
-    'MapView/Map/RMMapView.h',
-    'MapView/Map/RMMapViewDelegate.h',
-    'MapView/Map/RMMarker.h',
-    'MapView/Map/RMMemoryCache.h',
-    'MapView/Map/RMPointAnnotation.h',
-    'MapView/Map/RMPolygonAnnotation.h',
-    'MapView/Map/RMPolylineAnnotation.h',
-    'MapView/Map/RMShape.h',
-    'MapView/Map/RMStaticMapView.h',
-    'MapView/Map/RMTileCache.h',
-    'MapView/Map/RMTileMillSource.h',
-    'MapView/Map/RMUserLocation.h',
-    'MapView/Map/RMUserTrackingBarButtonItem.h'
+    'MapView/Map/*.h'
   ]
 
   m.resource_bundle = {


### PR DESCRIPTION
With CocoaPods 0.38 and SDK 0.6.1, we switched to explicitly, selectively listing our public headers in the podspec. This caused problems, because we need every header to successfully compile the project. 

Rather than maintain a long list of every header, this PR includes all the headers in `MapView/Map/*.h`.

Fixes #631, #636

/cc @incanus
