### PR TITLE
Ask for "always" location permissions, too

### DIFF
--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -3321,8 +3321,20 @@
         {
             BOOL hasLocationDescription = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationWhenInUseUsageDescription"] ||
                 [[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationAlwaysUsageDescription"];
-            NSAssert(hasLocationDescription, @"For iOS 8 and above, your app must have a value for NSLocationWhenInUseUsageDescription or NSLocationAlwaysUsageDescription in its Info.plist");
-            [_locationManager requestWhenInUseAuthorization];
+            if (!hasLocationDescription)
+            {
+                [NSException raise:@"Missing Location Services usage description" format:
+                 @"In iOS 8 and above, this app must have a value for NSLocationWhenInUseUsageDescription or NSLocationAlwaysUsageDescription in its Info.plist."];
+            }
+            // request location permissions, if both keys exist ask for less permissive
+            if ([[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationWhenInUseUsageDescription"])
+            {
+                [_locationManager requestWhenInUseAuthorization];
+            }
+            else if ([[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationAlwaysUsageDescription"])
+            {
+                [_locationManager requestAlwaysAuthorization];
+            }
         }
 #endif
 


### PR DESCRIPTION
If an iOS app only has the `NSLocationAlwaysUsageDescription` key, we will never ask the user for location permission. This PR checks for both `always` and `WhenInUse` permission keys, then asks the user (with a preference for the less permissive `WhenInUse`).

Fixes #648 (technically supersedes) by @duemunk, thanks!

/cc @incanus
