### PR TITLE
Added support for MultiPolygons to RMPolygonAnnotation

### DIFF
--- a/MapView/Map/RMPolygonAnnotation.h
+++ b/MapView/Map/RMPolygonAnnotation.h
@@ -42,6 +42,26 @@
 *   @return An initialized polygon annotation object, or `nil` if an annotation was unable to be initialized. */
 - (id)initWithMapView:(RMMapView *)aMapView points:(NSArray *)points interiorPolygons:(NSArray *)interiorPolygons;
 
+/**
+ *  Initialize a multipolygon annotation with multiple unconnected polygons.
+ *  @param aMapView The map view on which to place the annotation.
+ *  @param points An array of arrays of CLLocation points defining the polygons.
+ *
+ *  @return An initialized polygon annotation object, or `nil` if an annotation was unable to be initialized. */
+- (id)initWithMapView:(RMMapView *)aMapView polygons:(NSArray *)polygons;
+
+/**
+ *  Initialize a multipolygon annotation with multiple unconnected polygons.
+ *  @param aMapView The map view on which to place the annotation.
+ *  @param points An array of arrays of CLLocation points defining the polygons.
+ *  @param interiorPolygons An array of RMPolygonAnnotation objects that define one or more cutout regions for the receiver’s polygon.
+ *
+ *  @return An initialized polygon annotation object, or `nil` if an annotation was unable to be initialized. */
+- (id)initWithMapView:(RMMapView *)aMapView polygons:(NSArray *)polygons interiorPolygons:(NSArray *)interiorPolygons;
+
+/** The array of polygons (NSArrays inside an NSArray) if this is a multipolygon annotation. */
+@property (nonatomic, strong) NSArray *polygons;
+
 /** The array of polygons nested inside the receiver. (read-only)
 *
 *   When a polygon is rendered on screen, the area occupied by any interior polygons is masked out and not considered part of the polygon. */

--- a/MapView/Map/RMPolygonAnnotation.m
+++ b/MapView/Map/RMPolygonAnnotation.m
@@ -56,7 +56,7 @@
 
 - (id)initWithMapView:(RMMapView *)aMapView polygons:(NSArray *)polygons interiorPolygons:(NSArray *)interiorPolygons
 {
-    if (!(self = [super initWithMapView:aMapView points:polygons.firstObject]))
+    if (!(self = [super initWithMapView:aMapView points:[polygons valueForKeyPath: @"@unionOfArrays.self"]]))
         return nil;
     
     _polygons = polygons;

--- a/MapView/Map/RMPolygonAnnotation.m
+++ b/MapView/Map/RMPolygonAnnotation.m
@@ -49,6 +49,22 @@
     return self;
 }
 
+- (id)initWithMapView:(RMMapView *)aMapView polygons:(NSArray *)polygons
+{
+    return [self initWithMapView:aMapView polygons:polygons interiorPolygons:nil];
+}
+
+- (id)initWithMapView:(RMMapView *)aMapView polygons:(NSArray *)polygons interiorPolygons:(NSArray *)interiorPolygons
+{
+    if (!(self = [super initWithMapView:aMapView points:polygons.firstObject]))
+        return nil;
+    
+    _polygons = polygons;
+    _interiorPolygons = interiorPolygons;
+    
+    return self;
+}
+
 - (void)setLayer:(RMMapLayer *)newLayer
 {
     if ( ! newLayer)
@@ -65,12 +81,24 @@
 
         [shape performBatchOperations:^(RMShape *aShape)
         {
-            [aShape moveToCoordinate:self.coordinate];
-
-            for (CLLocation *point in self.points)
-                [aShape addLineToCoordinate:point.coordinate];
-
-            [aShape closePath];
+            if (self.polygons) {
+                for (NSArray *points in self.polygons)
+                {
+                    [aShape moveToCoordinate:[points.firstObject coordinate]];
+                    
+                    for (CLLocation *point in points)
+                        [aShape addLineToCoordinate:point.coordinate];
+                    
+                    [aShape moveToCoordinate:[points.firstObject coordinate]];
+                }
+            } else {
+                [aShape moveToCoordinate:self.coordinate];
+                
+                for (CLLocation *point in self.points)
+                    [aShape addLineToCoordinate:point.coordinate];
+                
+                [aShape closePath];
+            }
 
             if (self.interiorPolygons)
             {

--- a/MapView/Map/RMPolylineAnnotation.h
+++ b/MapView/Map/RMPolylineAnnotation.h
@@ -33,4 +33,19 @@
 *   If you wish to customize the layer appearance in more detail, you should instead create an RMAnnotation and configure its layer directly. Providing a layer manually for instances of RMPolylineAnnotation will not have any effect. */
 @interface RMPolylineAnnotation : RMShapeAnnotation
 
+/**
+ *  Create a polyline annotation with multiple polylines.
+ *
+ *  @param aMapView  The map view.
+ *  @param polylines An array of arrays of CLLocations. Each outer array represents on polyline.
+ *
+ *  @return The polyline annotation.
+ */
+- (id)initWithMapView:(RMMapView *)aMapView polylines:(NSArray *)polylines;
+
+/**
+ *  An array of CLLocation arrays for defining multiple polylines in one annotation.
+ */
+@property (nonatomic, strong) NSArray *polylines;
+
 @end

--- a/MapView/Map/RMPolylineAnnotation.m
+++ b/MapView/Map/RMPolylineAnnotation.m
@@ -32,6 +32,17 @@
 
 @implementation RMPolylineAnnotation
 
+- (id)initWithMapView:(RMMapView *)aMapView polylines:(NSArray *)polylines
+{
+    self = [super initWithMapView:aMapView points:[polylines valueForKeyPath: @"@unionOfArrays.self"]];
+    
+    if (self) {
+        self.polylines = polylines;
+    }
+        
+    return self;
+}
+
 - (void)setLayer:(RMMapLayer *)newLayer
 {
     if ( ! newLayer)
@@ -48,10 +59,19 @@
 
         [shape performBatchOperations:^(RMShape *aShape)
         {
-            [aShape moveToCoordinate:self.coordinate];
-
-            for (CLLocation *point in self.points)
-                [aShape addLineToCoordinate:point.coordinate];
+            if (self.polylines.count > 0) {
+                for (NSArray *polyline in self.polylines) {
+                    [aShape moveToCoordinate:[(CLLocation *)polyline.firstObject coordinate]];
+                    
+                    for (CLLocation *point in polyline)
+                        [aShape addLineToCoordinate:point.coordinate];
+                }
+            } else {
+                [aShape moveToCoordinate:self.coordinate];
+                
+                for (CLLocation *point in self.points)
+                    [aShape addLineToCoordinate:point.coordinate];
+            }
         }];
 
         super.layer = shape;


### PR DESCRIPTION
Enables annotations like this using a single RMPolygonAnnotation object.

![Screenshot](http://s.swic.name/cEQB/Screen%20Shot%202015-08-13%20at%2014.39.03.png)
