### PR TITLE
Update RMGreatCircleAnnotation.m

### DIFF
--- a/MapView/Map/RMGreatCircleAnnotation.m
+++ b/MapView/Map/RMGreatCircleAnnotation.m
@@ -67,6 +67,9 @@
             int numsegs = 100;
             NSMutableArray *coords = [NSMutableArray arrayWithCapacity:numsegs];
             double f = 0.0;
+            //add the first coordinate of the great circle to to layer...or else the great circle start showing on second coordinate
+            [coords addObject:[[CLLocation alloc] initWithLatitude:self.coordinate1.latitude longitude:self.coordinate1.longitude]];
+
             for(int i=1; i<=numsegs; i++)
             {
                 f += 1.0 / (float)numsegs;


### PR DESCRIPTION
When a great circle is drawn the first path from origin coordinate to first point on route is not showing.
The bug - the route starts from point 1, so adding:
            [coords addObject:[[CLLocation alloc] initWithLatitude:self.coordinate1.latitude longitude:self.coordinate1.longitude]];

fix this issue.
